### PR TITLE
fatroom's initial attempt

### DIFF
--- a/calculate_average_fatroom.sh
+++ b/calculate_average_fatroom.sh
@@ -16,5 +16,5 @@
 #
 
 
-JAVA_OPTS="-XX:+UseZGC"
+JAVA_OPTS="-Xms16G -Xmx16G"
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_fatroom

--- a/calculate_average_fatroom.sh
+++ b/calculate_average_fatroom.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+JAVA_OPTS="-XX:+UseZGC"
+time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_fatroom

--- a/calculate_average_fatroom.sh
+++ b/calculate_average_fatroom.sh
@@ -16,5 +16,6 @@
 #
 
 
-JAVA_OPTS="-Xms16G -Xmx16G"
+JAVA_OPTS="-Xnoclassgc -Xms16G -Xmx16G"
+
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_fatroom

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
@@ -17,12 +17,8 @@ package dev.morling.onebrc;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-import java.util.TreeMap;
+import java.nio.file.*;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collector;
 
@@ -56,7 +52,7 @@ public class CalculateAverage_fatroom {
             int measurement = 0;
             for (int i = 0; i < v.length(); i++) {
                 if (v.charAt(i) == ';') {
-                    measurement = numberCache.computeIfAbsent(v.substring(i), key -> {
+                    measurement = numberCache.computeIfAbsent(v.substring(i + 1), key -> {
                         int sign = 1;
                         int value = 0;
                         for (int j = 0; j < key.length(); j++) {

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
@@ -57,7 +57,7 @@ public class CalculateAverage_fatroom {
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append(min / 10.0).append("/").append(Math.round(sum / count * 10.0) / 100.0).append("/").append(max / 10.0);
+            sb.append(min / 10.0).append("/").append(Math.round(sum / count) / 10.0).append("/").append(max / 10.0);
             return sb.toString();
         }
     }
@@ -98,7 +98,7 @@ public class CalculateAverage_fatroom {
     }
 
     private static Map<String, MeasurementAggregator> processBuffer(MappedByteBuffer source, int length) {
-        Map<String, MeasurementAggregator> aggregates = new HashMap<>();
+        Map<String, MeasurementAggregator> aggregates = new HashMap<>(500);
         String station;
         byte[] buffer = new byte[64];
         int measurementLength;

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_fatroom.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright 2023 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.onebrc;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collector;
+
+import static java.util.stream.Collector.Characteristics.CONCURRENT;
+import static java.util.stream.Collectors.groupingByConcurrent;
+
+public class CalculateAverage_fatroom {
+
+    private static final String FILE = "./measurements.txt";
+
+    private static final Map<String, Integer> numberCache = new ConcurrentHashMap<>(2000);
+
+    private static class MeasurementAggregator {
+        private int min;
+        private int max;
+        private long sum;
+        private long count;
+
+        public MeasurementAggregator() {
+            this(Integer.MAX_VALUE, Integer.MIN_VALUE, 0, 0);
+        }
+
+        public MeasurementAggregator(int min, int max, long sum, long count) {
+            this.min = min;
+            this.max = max;
+            this.sum = sum;
+            this.count = count;
+        }
+
+        public void consume(String v) {
+            int measurement = 0;
+            for (int i = 0; i < v.length(); i++) {
+                if (v.charAt(i) == ';') {
+                    measurement = numberCache.computeIfAbsent(v.substring(i), key -> {
+                        int sign = 1;
+                        int value = 0;
+                        for (int j = 0; j < key.length(); j++) {
+                            int c = key.charAt(j);
+                            if (c == '-') {
+                                sign = -1;
+                                continue;
+                            }
+                            if (c == '.') {
+                                continue;
+                            }
+                            value = value * 10 + (c - '0');
+                        }
+                        value *= sign;
+                        return value;
+                    });
+                    break;
+                }
+            }
+
+            this.min = this.min < measurement ? this.min : measurement;
+            this.max = this.max > measurement ? this.max : measurement;
+            this.sum += measurement;
+            this.count++;
+        }
+
+        public MeasurementAggregator combineWith(MeasurementAggregator that) {
+            return new MeasurementAggregator(
+                    this.min < that.min ? this.min : that.min,
+                    this.max > that.max ? this.max : that.max,
+                    this.sum + that.sum,
+                    this.count + that.count);
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        var reader = new BufferedReader(new InputStreamReader(FileSystems.getDefault().provider().newInputStream(Paths.get(FILE)), StandardCharsets.UTF_8),
+                1024 * 32);
+
+        Collector<String, MeasurementAggregator, String> collector = Collector.of(
+                MeasurementAggregator::new,
+                MeasurementAggregator::consume,
+                MeasurementAggregator::combineWith,
+                agg -> String.format(Locale.ROOT, "%.1f/%.1f/%.1f", agg.min / 10.0, agg.sum / agg.count / 10.0, agg.max / 10.0),
+                CONCURRENT);
+
+        var measurements = new TreeMap<>(reader.lines()
+                .parallel()
+                .unordered()
+                .collect(groupingByConcurrent(v -> v.substring(0, v.indexOf(";")), collector)));
+
+        System.out.println(measurements);
+    }
+}


### PR DESCRIPTION
Changes:
* use mmap buffers 
* get some memory 
* Parallel stream
* Long arythmetic


The name of your implementation class:
dev.morling.onebrc.CalculateAverage_fatroom

The JDK build to use (of not specified, the latest OpenJDK 21 upstream build will be used).
OpenJDK 64-Bit Server VM Temurin-21.0.1+12 (build 21.0.1+12-LTS, mixed mode)

The execution time of the program (Apple M1 Max, 32Gb):
real    0m15.303s
user    1m9.326s
sys     0m23.102s
