### PR TITLE
Implementation - palmr

### DIFF
--- a/calculate_average_palmr.sh
+++ b/calculate_average_palmr.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+JAVA_OPTS="--enable-preview"
+time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_palmr

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
@@ -28,7 +28,7 @@ public class CalculateAverage_palmr {
     public static final int CHUNK_SIZE = 1024 * 1024 * 10; // Trial and error showed ~10MB to be a good size on our machine
     public static final int LITTLE_CHUNK_SIZE = 128; // Enough bytes to cover a station name and measurement value :fingers-crossed:
     public static final int STATION_NAME_BUFFER_SIZE = 50;
-    public static final int THREAD_COUNT = 8;
+    public static final int THREAD_COUNT = Math.min(8, Runtime.getRuntime().availableProcessors());
 
     public static void main(String[] args) throws IOException {
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
@@ -1,0 +1,244 @@
+/*
+ *  Copyright 2023 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.onebrc;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class CalculateAverage_palmr {
+
+    private static final String FILE = "./measurements.txt";
+    public static final int CHUNK_SIZE = 1024 * 1024 * 10; // Trial and error showed ~10MB to be a good size on our machine
+    public static final int LITTLE_CHUNK_SIZE = 128; // Enough bytes to cover a station name and measurement value :fingers-crossed:
+    public static final int STATION_NAME_BUFFER_SIZE = 50;
+    public static final int THREAD_COUNT = 8;
+
+    public static void main(String[] args) throws IOException {
+
+        @SuppressWarnings("resource") // It's faster to leak the file than be well-behaved
+        RandomAccessFile file = new RandomAccessFile(FILE, "r");
+        FileChannel channel = file.getChannel();
+        long fileSize = channel.size();
+
+        long threadChunk = fileSize / THREAD_COUNT;
+
+        Thread[] threads = new Thread[THREAD_COUNT];
+        ByteArrayKeyedMap[] results = new ByteArrayKeyedMap[THREAD_COUNT];
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            final int j = i;
+            long startPoint = j * threadChunk;
+            long endPoint = startPoint + threadChunk;
+            Thread thread = new Thread(() -> {
+                try {
+                    results[j] = readAndParse(channel, startPoint, endPoint, fileSize);
+                }
+                catch (Throwable t) {
+                    System.err.println("It's broken :(");
+                    // noinspection CallToPrintStackTrace
+                    t.printStackTrace();
+                }
+            });
+            threads[i] = thread;
+            thread.start();
+        }
+
+        ByteArrayKeyedMap finalAggregator = new ByteArrayKeyedMap();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            try {
+                threads[i].join();
+            }
+            catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            results[i].getAsTreeMap().forEach((_, v) -> {
+                MeasurementAggregator aggregator = finalAggregator.computeIfAbsent(v.stationName, v.stationName.length, v.stationNameHashCode);
+                aggregator.count += v.count;
+                aggregator.min = Math.min(aggregator.min, v.min);
+                aggregator.max = Math.max(aggregator.max, v.max);
+                aggregator.sum += v.sum;
+            });
+        }
+        System.out.println(finalAggregator.getAsTreeMap());
+    }
+
+    private static ByteArrayKeyedMap readAndParse(final FileChannel channel,
+                                                  final long startPoint,
+                                                  final long endPoint,
+                                                  final long fileSize) {
+        final State state = new State();
+
+        boolean skipFirstEntry = startPoint != 0;
+
+        long offset = startPoint;
+        while (offset < endPoint) {
+            parseData(channel, state, offset, Math.min(CHUNK_SIZE, fileSize - offset), false, skipFirstEntry);
+            skipFirstEntry = false;
+            offset += CHUNK_SIZE;
+        }
+
+        if (offset < fileSize) {
+            // Make sure we finish reading any partially read entry by going a little in to the next chunk, stopping at the first newline
+            parseData(channel, state, offset, Math.min(LITTLE_CHUNK_SIZE, fileSize - offset), true, false);
+        }
+
+        return state.aggregators;
+    }
+
+    private static void parseData(final FileChannel channel,
+                                  final State state,
+                                  final long offset,
+                                  final long bufferSize,
+                                  final boolean stopAtNewline,
+                                  final boolean skipFirstEntry) {
+        ByteBuffer byteBuffer;
+        try {
+            byteBuffer = channel.map(FileChannel.MapMode.READ_ONLY, offset, bufferSize);
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        boolean isSkippingToFirstCleanEntry = skipFirstEntry;
+
+        while (byteBuffer.hasRemaining()) {
+            byte currentChar = byteBuffer.get();
+
+            if (isSkippingToFirstCleanEntry) {
+                if (currentChar == '\n') {
+                    isSkippingToFirstCleanEntry = false;
+                }
+
+                continue;
+            }
+
+            if (currentChar == ';') {
+                state.parsingValue = true;
+            }
+            else if (currentChar == '\n') {
+                if (state.stationPointerEnd != 0) {
+                    double value = state.measurementValue / state.divisor;
+
+                    MeasurementAggregator aggregator = state.aggregators.computeIfAbsent(state.stationBuffer, state.stationPointerEnd, state.signedHashCode);
+                    aggregator.count++;
+                    aggregator.min = Math.min(aggregator.min, value);
+                    aggregator.max = Math.max(aggregator.max, value);
+                    aggregator.sum += value;
+                }
+
+                if (stopAtNewline) {
+                    return;
+                }
+
+                // reset
+                state.reset();
+            }
+            else {
+                if (!state.parsingValue) {
+                    state.stationBuffer[state.stationPointerEnd++] = currentChar;
+                    state.signedHashCode = 31 * state.signedHashCode + (currentChar & 0xff);
+                }
+                else {
+                    if (currentChar == '-') {
+                        state.divisor = -10;
+                    }
+                    else if (currentChar != '.') {
+                        state.measurementValue = state.measurementValue * 10 + (currentChar - '0');
+                    }
+                }
+            }
+        }
+    }
+
+    static final class State {
+        ByteArrayKeyedMap aggregators = new ByteArrayKeyedMap();
+        boolean parsingValue = false;
+        byte[] stationBuffer = new byte[STATION_NAME_BUFFER_SIZE];
+        int signedHashCode = 0;
+        int stationPointerEnd = 0;
+        double measurementValue = 0;
+        double divisor = 10;
+
+        public void reset() {
+            parsingValue = false;
+            signedHashCode = 0;
+            stationPointerEnd = 0;
+            measurementValue = 0;
+            divisor = 10;
+        }
+    }
+
+    private static class MeasurementAggregator {
+        public final byte[] stationName;
+        public final int stationNameHashCode;
+        private double min = Double.POSITIVE_INFINITY;
+        private double max = Double.NEGATIVE_INFINITY;
+        private double sum;
+        private long count;
+
+        public MeasurementAggregator(final byte[] stationName, final int stationNameHashCode) {
+            this.stationName = stationName;
+            this.stationNameHashCode = stationNameHashCode;
+        }
+
+        public String toString() {
+            return round(min) + "/" + round(sum / count) + "/" + round(max);
+        }
+
+        private double round(double value) {
+            return Math.round(value * 10.0) / 10.0;
+        }
+    }
+
+    private static class ByteArrayKeyedMap {
+        private final int BUCKET_COUNT = 0xFFF; // 413 unique stations in the data set, & 0xFFF ~= 399 (only 14 collisions (given our hashcode implementation))
+        private final MeasurementAggregator[] buckets = new MeasurementAggregator[BUCKET_COUNT + 1];
+        private final TreeMap<String, MeasurementAggregator> sortedMap = new TreeMap<>();
+
+        public MeasurementAggregator computeIfAbsent(final byte[] key, final int keyLength, final int keyHashCode) {
+            int index = keyHashCode & BUCKET_COUNT;
+
+            while (true) {
+                MeasurementAggregator maybe = buckets[index];
+                if (maybe == null) {
+                    final byte[] copiedKey = Arrays.copyOf(key, keyLength);
+                    MeasurementAggregator measurementAggregator = new MeasurementAggregator(copiedKey, keyHashCode);
+                    buckets[index] = measurementAggregator;
+                    sortedMap.put(new String(key, 0, keyLength, StandardCharsets.UTF_8), measurementAggregator);
+                    return measurementAggregator;
+                }
+                else {
+                    if (Arrays.equals(key, 0, keyLength, maybe.stationName, 0, maybe.stationName.length)) {
+                        return maybe;
+                    }
+                    index++;
+                    index &= BUCKET_COUNT;
+                }
+            }
+        }
+
+        public Map<String, MeasurementAggregator> getAsTreeMap() {
+            return sortedMap;
+        }
+    }
+}

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
@@ -143,7 +143,7 @@ public class CalculateAverage_palmr {
             }
             else if (currentChar == '\n') {
                 if (state.stationPointerEnd != 0) {
-                    double value = (double) state.measurementValue * state.exponent;
+                    double value = state.measurementValue * state.exponent;
 
                     MeasurementAggregator aggregator = state.aggregators.computeIfAbsent(state.stationBuffer, state.stationPointerEnd, state.signedHashCode);
                     aggregator.count++;
@@ -182,7 +182,7 @@ public class CalculateAverage_palmr {
         byte[] stationBuffer = new byte[STATION_NAME_BUFFER_SIZE];
         int signedHashCode = 0;
         int stationPointerEnd = 0;
-        long measurementValue = 0;
+        double measurementValue = 0;
         double exponent = 0.1;
 
         public void reset() {

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
@@ -143,7 +143,7 @@ public class CalculateAverage_palmr {
             }
             else if (currentChar == '\n') {
                 if (state.stationPointerEnd != 0) {
-                    double value = state.measurementValue / state.divisor;
+                    double value = (double)state.measurementValue * state.exponent;
 
                     MeasurementAggregator aggregator = state.aggregators.computeIfAbsent(state.stationBuffer, state.stationPointerEnd, state.signedHashCode);
                     aggregator.count++;
@@ -166,7 +166,7 @@ public class CalculateAverage_palmr {
                 }
                 else {
                     if (currentChar == '-') {
-                        state.divisor = -10;
+                        state.exponent = -1.0e1;
                     }
                     else if (currentChar != '.') {
                         state.measurementValue = state.measurementValue * 10 + (currentChar - '0');
@@ -182,15 +182,15 @@ public class CalculateAverage_palmr {
         byte[] stationBuffer = new byte[STATION_NAME_BUFFER_SIZE];
         int signedHashCode = 0;
         int stationPointerEnd = 0;
-        double measurementValue = 0;
-        double divisor = 10;
+        long measurementValue = 0;
+        double exponent = 1.0e1;
 
         public void reset() {
             parsingValue = false;
             signedHashCode = 0;
             stationPointerEnd = 0;
             measurementValue = 0;
-            divisor = 10;
+            exponent = 1.0e1;
         }
     }
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_palmr.java
@@ -143,7 +143,7 @@ public class CalculateAverage_palmr {
             }
             else if (currentChar == '\n') {
                 if (state.stationPointerEnd != 0) {
-                    double value = (double)state.measurementValue * state.exponent;
+                    double value = (double) state.measurementValue * state.exponent;
 
                     MeasurementAggregator aggregator = state.aggregators.computeIfAbsent(state.stationBuffer, state.stationPointerEnd, state.signedHashCode);
                     aggregator.count++;
@@ -166,7 +166,7 @@ public class CalculateAverage_palmr {
                 }
                 else {
                     if (currentChar == '-') {
-                        state.exponent = -1.0e1;
+                        state.exponent = -0.1;
                     }
                     else if (currentChar != '.') {
                         state.measurementValue = state.measurementValue * 10 + (currentChar - '0');
@@ -183,14 +183,14 @@ public class CalculateAverage_palmr {
         int signedHashCode = 0;
         int stationPointerEnd = 0;
         long measurementValue = 0;
-        double exponent = 1.0e1;
+        double exponent = 0.1;
 
         public void reset() {
             parsingValue = false;
             signedHashCode = 0;
             stationPointerEnd = 0;
             measurementValue = 0;
-            exponent = 1.0e1;
+            exponent = 0.1;
         }
     }
 


### PR DESCRIPTION
My implementation: `CalculateAverage_palmr`
Was using `Zulu21.30+15-CA (build 21.0.1+12-LTS)` for JDK but nothing specific to Zulu.

Memory mapped file, single-pass parsing, custom hash map, fixed size thread pool
The threading was a hasty addition and needs work. On a single thread we got it down to ~40s locally.

An assumption has been made that measurement values are all 1 decimal place. Hoping that's fair :crossed_fingers: 

Locally seeing on Linux 6.1.8 (Fedora 36), AMD Ryzen 9 5950X, 128GB RAM, NVMe disk (AKA not representative of the SUT at all, but hey):

```shell
#  ./calculate_average.sh
real    2m3.411s
user    2m1.455s
sys     0m2.821s

# ./calculate_average_bjhara.sh
real    0m10.318s
user    4m22.220s
sys     0m10.747s

#  ./calculate_average_palmr.sh
real    0m5.787s
user    0m42.884s
sys     0m0.796s
```