### PR TITLE
Minor improvement to @spullara

### DIFF
--- a/calculate_average_hundredwatt.sh
+++ b/calculate_average_hundredwatt.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+
+JAVA_OPTS=""
+sdk use java 21.0.1-graalce
+time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_hundredwatt
+

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,8 @@
               <strictCheck>true</strictCheck>
               <aggregate>true</aggregate>
               <excludes>
+                <exclude>*.html</exclude>
+                <exclude>*.jfr</exclude>
                 <exclude>LICENSE.txt</exclude>
                 <exclude>**/.dontdelete</exclude>
                 <exclude>**/measurements*.txt</exclude>

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_hundredwatt.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_hundredwatt.java
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2023 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.onebrc;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+
+public class CalculateAverage_hundredwatt {
+    private static final String FILE = "./measurements.txt";
+
+    /*
+     * My results on this computer:
+     *
+     * CalculateAverage: 2m37.788s
+     * CalculateAverage_royvanrijn: 0m29.639s
+     * CalculateAverage_spullara: 0m2.013s
+     *
+     */
+
+    public static void main(String[] args) throws IOException, ExecutionException, InterruptedException {
+        long start = System.currentTimeMillis();
+        var filename = args.length == 0 ? FILE : args[0];
+        var file = new File(filename);
+
+        var resultsMap = getFileSegments(file).stream().map(segment -> {
+            var resultMap = new ByteArrayToResultMap();
+            long segmentEnd = segment.end();
+            try (var fileChannel = (FileChannel) Files.newByteChannel(Path.of(filename), StandardOpenOption.READ)) {
+                var bb = fileChannel.map(FileChannel.MapMode.READ_ONLY, segment.start(), segmentEnd - segment.start());
+                // Up to 100 characters for a city name
+                var buffer = new byte[100];
+                int startLine;
+                int limit = bb.limit();
+                while ((startLine = bb.position()) < limit) {
+                    int currentPosition = startLine;
+                    byte b;
+                    int offset = 0;
+                    int hash = 0;
+                    while (currentPosition != segmentEnd && (b = bb.get(currentPosition++)) != ';') {
+                        buffer[offset++] = b;
+                        hash = 31 * hash + b;
+                    }
+                    int temp;
+                    int negative = 1;
+                    // Inspired by @yemreinci to unroll this even further
+                    if (bb.get(currentPosition) == '-') {
+                        negative = -1;
+                        currentPosition++;
+                    }
+                    if (bb.get(currentPosition + 1) == '.') {
+                        temp = negative * ((bb.get(currentPosition) - '0') * 10 + (bb.get(currentPosition + 2) - '0'));
+                        currentPosition += 3;
+                    }
+                    else {
+                        temp = negative * ((bb.get(currentPosition) - '0') * 100 + ((bb.get(currentPosition + 1) - '0') * 10 + (bb.get(currentPosition + 3) - '0')));
+                        currentPosition += 4;
+                    }
+                    if (bb.get(currentPosition) == '\r') {
+                        currentPosition++;
+                    }
+                    currentPosition++;
+                    resultMap.putOrMerge(buffer, 0, offset, temp / 10.0, hash);
+                    bb.position(currentPosition);
+                }
+                return resultMap;
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }).parallel().flatMap(partition -> partition.getAll().stream())
+                .collect(Collectors.toMap(e -> new String(e.key()), Entry::value, CalculateAverage_hundredwatt::merge, TreeMap::new));
+
+        System.out.println(resultsMap);
+    }
+
+    private static List<FileSegment> getFileSegments(File file) throws IOException {
+        int numberOfSegments = Runtime.getRuntime().availableProcessors();
+        long fileSize = file.length();
+        long segmentSize = fileSize / numberOfSegments;
+        List<FileSegment> segments = new ArrayList<>(numberOfSegments);
+        // Pointless to split small files
+        if (segmentSize < 1_000_000) {
+            segments.add(new FileSegment(0, fileSize));
+            return segments;
+        }
+        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+            for (int i = 0; i < numberOfSegments; i++) {
+                long segStart = i * segmentSize;
+                long segEnd = (i == numberOfSegments - 1) ? fileSize : segStart + segmentSize;
+                segStart = findSegment(i, 0, randomAccessFile, segStart, segEnd);
+                segEnd = findSegment(i, numberOfSegments - 1, randomAccessFile, segEnd, fileSize);
+
+                segments.add(new FileSegment(segStart, segEnd));
+            }
+        }
+        return segments;
+    }
+
+    private static Result merge(Result v, Result value) {
+        return merge(v, value.min, value.max, value.sum, value.count);
+    }
+
+    private static Result merge(Result v, double value, double value1, double value2, long value3) {
+        v.min = Math.min(v.min, value);
+        v.max = Math.max(v.max, value1);
+        v.sum += value2;
+        v.count += value3;
+        return v;
+    }
+
+    private static long findSegment(int i, int skipSegment, RandomAccessFile raf, long location, long fileSize) throws IOException {
+        if (i != skipSegment) {
+            raf.seek(location);
+            while (location < fileSize) {
+                location++;
+                if (raf.read() == '\n')
+                    break;
+            }
+        }
+        return location;
+    }
+}
+
+// use classes from _spullara:
+// * Result
+// * Entry
+// * FileSegment
+// * ByteArrayToResultMap

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_hundredwatt.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_hundredwatt.java
@@ -56,10 +56,16 @@ public class CalculateAverage_hundredwatt {
                 int startLine;
                 int limit = bb.limit();
                 while ((startLine = bb.position()) < limit) {
-                    int currentPosition = startLine;
                     byte b;
-                    int offset = 0;
-                    int hash = 0;
+                    int hash, offset, currentPosition;
+
+                    // first character
+                    buffer[0] = bb.get(startLine);
+                    hash = buffer[0]; // 31 * 0 + b == b
+                    offset = 1;
+                    currentPosition = startLine + 1;
+
+                    // rest of city name characters until ';'
                     while (currentPosition != segmentEnd && (b = bb.get(currentPosition++)) != ';') {
                         buffer[offset++] = b;
                         hash = 31 * hash + b;


### PR DESCRIPTION
I forked @spullara's file and made a minor improvement that reduces execution time by 2-3%.

This reduced executive time from `~9.5` to `~9.3s` in hyperfine with 5 runs

* Class Name: `CalculateAverage_hundredwatt`
* Machine specs: 8 cores, 32GB RAM
* JVM: 21.0.1-graalce

Improvement:

* Hard-code processing of the first character of the city name (which can never be `;` according to the input value ranges in the README), commit: 0ffa9bcc6944df4db2e0177e09640861631bc813

I ran hyperfine twice with benchmark order reversed the second time and saw the same results.

<img width="1020" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/56d27cb7-dab6-4b15-a3bb-47f6d255549c">

Hyperfine command:

```
hyperfine --warmup 1 --runs 5 ' java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_yemreinci' ' java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_hundredwatt'
```

(Note: hostname of this machine is `fedora-s-8vcpu-16gb-amd-sfo3-01`, but I resized it to have 32gb of RAM)