### PR TITLE
More optimizations for ebarlas submission

### DIFF
--- a/calculate_average_ebarlas.sh
+++ b/calculate_average_ebarlas.sh
@@ -15,6 +15,7 @@
 #  limitations under the License.
 #
 
+source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk use java 21.0.1-graalce
 JAVA_OPTS=""
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ebarlas measurements.txt 8

--- a/calculate_average_ebarlas.sh
+++ b/calculate_average_ebarlas.sh
@@ -16,6 +16,6 @@
 #
 
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk use java 21.0.1-graalce
+sdk use java 21.0.1-graalce 1>&2
 JAVA_OPTS=""
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ebarlas measurements.txt 8


### PR DESCRIPTION
Implementation class: `CalculateAverage_ebarlas`

Runtime on `c5.2xlarge` EC2 instance:
```
real	0m7.920s
user	1m0.896s
sys	0m0.664s
```

I added the following line in an attempt to smoothen the sdk selection process. Please be sure GraalVM is selected as it provides a noticeable speed-up over base OpenJDK.

```
source "$HOME/.sdkman/bin/sdkman-init.sh"
```