### PR TITLE
CalculateAverage_truelive second attempt

### DIFF
--- a/calculate_average_truelive.sh
+++ b/calculate_average_truelive.sh
@@ -15,6 +15,8 @@
 #  limitations under the License.
 #
 
-sdk use java 21.0.1-graalce
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+sdk use java 21.0.1-graalce 1>&2
+
 JAVA_OPTS="-Xmx8G -Xms2G"
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_truelive

--- a/calculate_average_truelive.sh
+++ b/calculate_average_truelive.sh
@@ -15,6 +15,6 @@
 #  limitations under the License.
 #
 
-
-JAVA_OPTS="-Xmx4G"
+sdk use java 21.0.1-graalce
+JAVA_OPTS="-Xmx8G -Xms2G"
 time java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_truelive

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -31,33 +31,6 @@ public class CalculateAverage_truelive {
     private static final String FILE = "./measurements.txt";
     private static final long CHUNK_SIZE = 1024 * 1024 * 10L;
 
-    private static int branchlessParseInt(final byte[] input, final int length) {
-        // 0 if positive, 1 if negative
-        final int negative = ~(input[0] >> 4) & 1;
-        // 0 if nr length is 3, 1 if length is 4
-        final int has4 = ((length - negative) >> 2) & 1;
-
-        final int digit1 = input[negative] - '0';
-        final int digit2 = input[negative + has4] - '0';
-        final int digit3 = input[2 + negative + has4] - '0';
-
-        return (-negative ^ (has4 * (digit1 * 100) + digit2 * 10 + digit3) - negative);
-    }
-
-    // branchless max (unprecise for large numbers, but good enough)
-    static int max(final int a, final int b) {
-        final int diff = a - b;
-        final int dsgn = diff >> 31;
-        return a - (diff & dsgn);
-    }
-
-    // branchless min (unprecise for large numbers, but good enough)
-    static int min(final int a, final int b) {
-        final int diff = a - b;
-        final int dsgn = diff >> 31;
-        return b + (diff & dsgn);
-    }
-
     private record Measurement(DoubleAccumulator min, DoubleAccumulator max, DoubleAccumulator sum, LongAdder count) {
         public static Measurement of(final Double initialMeasurement) {
             final Measurement measurement = new Measurement(
@@ -102,16 +75,6 @@ public class CalculateAverage_truelive {
                     m1.count
             );
         }
-    }
-
-    private static Map<String, Measurement> combineMaps(
-                                                        final Map<String, Measurement> map1,
-                                                        final Map<String, Measurement> map2) {
-        for (final var entry : map2.entrySet()) {
-            map1.merge(entry.getKey(), entry.getValue(), Measurement::combineWith);
-        }
-
-        return map1;
     }
 
     public static void main(final String[] args) throws IOException {

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -93,58 +93,6 @@ public class CalculateAverage_truelive {
         }
     }
 
-    static class Mes {
-        int min; int max; int sum; long count;
-
-        public Mes(int min, int max, int sum, long count) {
-            this.max = max;
-            this.min = min;
-            this.sum = sum;
-            this.count = count;
-
-        }
-
-        public static Mes of(final int mes) {
-            final Mes measurement = new Mes(
-                    mes,
-                    mes,
-                    mes,
-                    1
-            );
-            return measurement;
-        }
-
-        public Mes add(final int measurment) {
-            min = Math.min(min, measurment);
-            max = Math.max(max, measurment);
-            sum += measurment;
-            count++;
-            return this;
-        }
-
-        public String toString() {
-            return round(min) +
-                   "/" +
-                   round(((double) sum) / count) +
-                   "/" +
-                   round(max);
-        }
-
-        private double round(final double value) {
-            return Math.round(value) / 10.0;
-        }
-
-        public static Mes combineWith(final Mes m1, final Mes m2) {
-
-            return new Mes(
-                    Math.min(m1.min, m2.min),
-                    Math.max(m1.max, m2.max),
-                    m1.sum + m2.sum,
-                    m1.count + m2.count
-            );
-        }
-    }
-
     public static void main(final String[] args) throws IOException {
         // long before = System.currentTimeMillis();
         /**

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -23,6 +23,7 @@ import java.nio.channels.FileChannel;
 import java.util.*;
 import java.util.concurrent.atomic.DoubleAccumulator;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -92,6 +93,58 @@ public class CalculateAverage_truelive {
         }
     }
 
+    static class Mes {
+        int min; int max; int sum; long count;
+
+        public Mes(int min, int max, int sum, long count) {
+            this.max = max;
+            this.min = min;
+            this.sum = sum;
+            this.count = count;
+
+        }
+
+        public static Mes of(final int mes) {
+            final Mes measurement = new Mes(
+                    mes,
+                    mes,
+                    mes,
+                    1
+            );
+            return measurement;
+        }
+
+        public Mes add(final int measurment) {
+            min = Math.min(min, measurment);
+            max = Math.max(max, measurment);
+            sum += measurment;
+            count++;
+            return this;
+        }
+
+        public String toString() {
+            return round(min) +
+                   "/" +
+                   round(((double) sum) / count) +
+                   "/" +
+                   round(max);
+        }
+
+        private double round(final double value) {
+            return Math.round(value) / 10.0;
+        }
+
+        public static Mes combineWith(final Mes m1, final Mes m2) {
+
+            return new Mes(
+                    Math.min(m1.min, m2.min),
+                    Math.max(m1.max, m2.max),
+                    m1.sum + m2.sum,
+                    m1.count + m2.count
+            );
+        }
+    }
+
     public static void main(final String[] args) throws IOException {
         // long before = System.currentTimeMillis();
         /**
@@ -157,18 +210,15 @@ public class CalculateAverage_truelive {
         String name = null;
         final byte[] arr = new byte[128];
         int cur = 0;
-        int hash = 0;
         while (bug.hasRemaining()) {
             char c = (char) bug.get();
             arr[cur++] = (byte) c;
             while (c != ';') {
-                hash += 31 * hash + c;
                 c = (char) bug.get();
                 arr[cur++] = (byte) c;
             }
             name = new String(arr, 0, cur - 1);
             cur = 0;
-            hash = 0;
             while (c != '\n') {
                 c = (char) bug.get();
                 arr[cur++] = (byte) c;

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -32,7 +32,6 @@ public class CalculateAverage_truelive {
     private static final String FILE = "./measurements.txt";
     private static final long CHUNK_SIZE = 1024 * 1024 * 10L;
 
-
     private static double getDouble(final byte[] arr, int pos) {
         final int negative = ~(arr[pos] >> 4) & 1;
         int sig = 1;
@@ -41,9 +40,10 @@ public class CalculateAverage_truelive {
         final int digit1 = arr[pos] - '0';
         pos++;
         if (arr[pos] == '.') {
-            return sig * (digit1  + (arr[pos + 1] - '0')/10.0 );
-        } else {
-            return sig * (digit1 * 10 + (arr[pos] - '0')  + (arr[pos + 2] - '0')/10.0 );
+            return sig * (digit1 + (arr[pos + 1] - '0') / 10.0);
+        }
+        else {
+            return sig * (digit1 * 10 + (arr[pos] - '0') + (arr[pos + 2] - '0') / 10.0);
         }
     }
 
@@ -131,23 +131,17 @@ public class CalculateAverage_truelive {
                 }
             }
         };
+
         final Map<String, Measurement> reduce = StreamSupport.stream(Spliterators.spliteratorUnknownSize(
                 iterator, Spliterator.IMMUTABLE), true)
-                .parallel()
                 .map(CalculateAverage_truelive::parseBuffer)
-                .reduce(CalculateAverage_truelive::combineMaps).get();
-
-        System.out.print("{");
-        System.out.print(
-                reduce
-                        .entrySet()
-                        .stream()
-                        .sorted(Map.Entry.comparingByKey())
-                        .map(Object::toString)
-                        .collect(Collectors.joining(", ")));
-        System.out.println("}");
-
-        // System.out.println("Took: " + (System.currentTimeMillis() - before));
+                .flatMap(map -> map.entrySet().stream())
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        Measurement::combineWith,
+                        TreeMap::new));
+        System.out.println(reduce);
 
     }
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -31,6 +31,7 @@ public class CalculateAverage_truelive {
     private static final String FILE = "./measurements.txt";
     private static final long CHUNK_SIZE = 1024 * 1024 * 10L;
 
+
     private static double getDouble(final byte[] arr, int pos) {
         final int negative = ~(arr[pos] >> 4) & 1;
         int sig = 1;
@@ -155,29 +156,28 @@ public class CalculateAverage_truelive {
         bug.mark();
         String name = null;
         final byte[] arr = new byte[128];
+        int cur = 0;
+        int hash = 0;
         while (bug.hasRemaining()) {
-            final char c = (char) bug.get();
-            if (c == ';') {
-                final int pos = bug.position();
-                bug.reset();
-                final int len = pos - bug.position() - 1;
-                bug.get(bug.position(), arr, 0, len);
-                name = new String(arr, 0, len);
-                bug.position(pos);
-                bug.mark();
+            char c = (char) bug.get();
+            arr[cur++] = (byte) c;
+            while (c != ';') {
+                hash += 31 * hash + c;
+                c = (char) bug.get();
+                arr[cur++] = (byte) c;
             }
-            else if (c == '\n') {
-                final int pos = bug.position();
-                bug.reset();
-                final int len = pos - bug.position();
-                bug.get(bug.position(), arr, 0, len);
-                //final double temp = Double.parseDouble(new String(arr, 0, len));
-                final double temp = getDouble(arr, 0);
-                resultMap.compute(name, (k, v) -> (v == null) ? Measurement.of(temp) : v.add(temp));
-                bug.position(pos);
-                bug.mark();
+            name = new String(arr, 0, cur - 1);
+            cur = 0;
+            hash = 0;
+            while (c != '\n') {
+                c = (char) bug.get();
+                arr[cur++] = (byte) c;
             }
+            final double temp = getDouble(arr, 0);
+            resultMap.compute(name, (k, v) -> (v == null) ? Measurement.of(temp) : v.add(temp));
+            cur = 0;
         }
         return resultMap;
     }
+
 }

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_truelive.java
@@ -31,6 +31,20 @@ public class CalculateAverage_truelive {
     private static final String FILE = "./measurements.txt";
     private static final long CHUNK_SIZE = 1024 * 1024 * 10L;
 
+    private static double getDouble(final byte[] arr, int pos) {
+        final int negative = ~(arr[pos] >> 4) & 1;
+        int sig = 1;
+        sig -= 2 * negative;
+        pos += negative;
+        final int digit1 = arr[pos] - '0';
+        pos++;
+        if (arr[pos] == '.') {
+            return sig * (digit1  + (arr[pos + 1] - '0')/10.0 );
+        } else {
+            return sig * (digit1 * 10 + (arr[pos] - '0')  + (arr[pos + 2] - '0')/10.0 );
+        }
+    }
+
     private record Measurement(DoubleAccumulator min, DoubleAccumulator max, DoubleAccumulator sum, LongAdder count) {
         public static Measurement of(final Double initialMeasurement) {
             final Measurement measurement = new Measurement(
@@ -157,7 +171,8 @@ public class CalculateAverage_truelive {
                 bug.reset();
                 final int len = pos - bug.position();
                 bug.get(bug.position(), arr, 0, len);
-                final double temp = Double.parseDouble(new String(arr, 0, len));
+                //final double temp = Double.parseDouble(new String(arr, 0, len));
+                final double temp = getDouble(arr, 0);
                 resultMap.compute(name, (k, v) -> (v == null) ? Measurement.of(temp) : v.add(temp));
                 bug.position(pos);
                 bug.mark();


### PR DESCRIPTION
Just removing double parsing shaves off alot.
My implementation: `CalculateAverage_truelive`
Was using `Windows 11` and `GraalVM 21`.

Also GraalVm just magically boosts the whole process. Both GraalVm and OpenJDK spent 100% CPU.


Locally `6.5s` average, AMD Ryzen 9 3900X (12 cores), 64GB RAM. I would expect 20s leaderboard time =)