### PR TITLE
Improvement in CalculateAverage_yavuztas

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
@@ -37,10 +37,14 @@ public class CalculateAverage_yavuztas {
     private static final Path FILE = Path.of("./measurements.txt");
 
     static class Measurement {
+
+        // Only accessed by a single thread, so it is safe to share
+        private static final StringBuilder STRING_BUILDER = new StringBuilder(14);
+
         private int min; // calculations over int is faster than double, we convert to double in the end only once
         private int max;
-        private int sum;
-        private int count = 1;
+        private long sum;
+        private long count = 1;
 
         public Measurement(int initial) {
             this.min = initial;
@@ -48,12 +52,14 @@ public class CalculateAverage_yavuztas {
             this.sum = initial;
         }
 
-        public String toString() { // convert to double while generating the string output
-            return valueOf(this.min) + "/" + round(valueOf(this.sum) / this.count) + "/" + valueOf(this.max);
-        }
-
-        private double valueOf(int value) {
-            return value / 10.0;
+        public String toString() {
+            STRING_BUILDER.setLength(0); // clear the builder to reuse
+            STRING_BUILDER.append(this.min / 10.0); // convert to double while generating the string output
+            STRING_BUILDER.append("/");
+            STRING_BUILDER.append(round((this.sum / 10.0) / this.count));
+            STRING_BUILDER.append("/");
+            STRING_BUILDER.append(this.max / 10.0);
+            return STRING_BUILDER.toString();
         }
 
         private double round(double value) {

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
@@ -126,6 +126,7 @@ public class CalculateAverage_yavuztas {
                 while ((b = this.buffer.get()) != '\n') {
                     if (b == ';') { // save semicolon pos
                         semiColonPos = this.buffer.position(); // semicolon exclusive
+                        skip(3);
                     }
                 }
                 // found linebreak

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
@@ -72,9 +72,9 @@ public class CalculateAverage_yavuztas {
         ByteBuffer value;
         int hash;
 
-        public KeyBuffer(ByteBuffer buffer) {
+        public KeyBuffer(ByteBuffer buffer, int hash) {
             this.value = buffer;
-            this.hash = buffer.hashCode();
+            this.hash = hash;
         }
 
         @Override
@@ -122,17 +122,17 @@ public class CalculateAverage_yavuztas {
             int semiColonPos;
             while (this.buffer.hasRemaining()) {
 
-                while (true) {
-                    if (this.buffer.get() == ';') // read until semicolon
-                        break;
+                int b;
+                int keyHash = 0;
+                while ((b = this.buffer.get()) != ';') { // read until semicolon
+                    keyHash = 31 * keyHash + b; // calculate key hash ahead, eleminates one more loop later
                 }
 
                 semiColonPos = this.buffer.position(); // semicolon pos, exclusive
                 skip(3); // skip more since minimum temperature length is 3
 
-                while (true) {
-                    if (this.buffer.get() == '\n') // read until linebreak
-                        break;
+                while (this.buffer.get() != '\n') {
+                    // read until linebreak
                 }
                 lineBreakPos = this.buffer.position(); // found linebreak, exclusive
 
@@ -145,7 +145,7 @@ public class CalculateAverage_yavuztas {
 
                 this.position = lineBreakPos; // skip to line end
 
-                consumer.accept(new KeyBuffer(station), temperature);
+                consumer.accept(new KeyBuffer(station, keyHash), temperature);
             }
         }
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_yavuztas.java
@@ -118,19 +118,23 @@ public class CalculateAverage_yavuztas {
 
         void traverse(BiConsumer<KeyBuffer, Integer> consumer) {
 
-            int lineBreakPos = 0;
-            int semiColonPos = 0;
+            int lineBreakPos;
+            int semiColonPos;
             while (this.buffer.hasRemaining()) {
 
-                byte b;
-                while ((b = this.buffer.get()) != '\n') {
-                    if (b == ';') { // save semicolon pos
-                        semiColonPos = this.buffer.position(); // semicolon exclusive
-                        skip(3);
-                    }
+                while (true) {
+                    if (this.buffer.get() == ';') // read until semicolon
+                        break;
                 }
-                // found linebreak
-                lineBreakPos = this.buffer.position();
+
+                semiColonPos = this.buffer.position(); // semicolon pos, exclusive
+                skip(3); // skip more since minimum temperature length is 3
+
+                while (true) {
+                    if (this.buffer.get() == '\n') // read until linebreak
+                        break;
+                }
+                lineBreakPos = this.buffer.position(); // found linebreak, exclusive
 
                 this.buffer.position(this.position); // set back to line start
                 final int length1 = semiColonPos - this.position; // station length


### PR DESCRIPTION
Hi @gunnarmorling 

I improved my solution inspired by the famous @peter-lawrey's solution. It should be 2-3 seconds faster now :)

The changes are in general:
- improve double reading by eliminating string parsing in between
- make calculations over on integer instead of double
- parse into double at the end only once
- remove the character limit per line, it works now independent of the line length
 
Could you please reevaluate when you have time?

Many thanks!

#### Check List:
- [x] Tests pass (`./test.sh <username>`)
- [x] All formatting changes by the build are committed
- [x] Output matches that of calculate_average_baseline.sh
* Execution time: ~8s (on Macbook Pro m2 16 Core 32 GB Ram)
* Execution time of reference implementation: which one? baseline?? It's 3m 22s

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Please submit only submissions that are taking less than 1 minute.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits)
-->
