### PR TITLE
seijikun: Fix new unit-test introduced with #125

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_seijikun.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_seijikun.java
@@ -62,10 +62,6 @@ public class CalculateAverage_seijikun {
 
         public StationIdent(byte[] name, int nameHash) {
             this.name = name;
-            // TODO: DEBUG
-            // if(Arrays.asList(this.name).contains(';')) {
-            // throw new RuntimeException();
-            // }
             this.nameHash = nameHash;
         }
 
@@ -122,7 +118,7 @@ public class CalculateAverage_seijikun {
         private StationIdent readStationName() {
             final var VECTOR_SPECIES = ByteVector.SPECIES_256;
 
-            if (chunkSize - ptr < VECTOR_SPECIES.length()) { // fallback
+            if (chunkSize - ptr - 100 < VECTOR_SPECIES.length()) { // fallback
                 int startPtr = ptr;
                 while (buffer.get(ptr++) != ';') {
                 }


### PR DESCRIPTION
I tried to refactor this code for hours now, but whenever I touch anything in `readStationName()`, the performance deteriorates massively, without any identifiable reason.

Seems like I accidentally hit a magic sweetspot in the C2 Hotspot compiler Vector API support stuff in the way that the code is structured now.