### PR TITLE
Use hyperfine and jq to improve evaluate.sh

### DIFF
--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -65,4 +65,10 @@ echo "command,trimmed_mean"
 jq -r '.results[] | [ .command, ((.times | sort) | .[1:-1] | add / length) ] | join(",")' $TEMP_FILE \
   | perl -pe 's/^[.]\/calculate_average_(\w+).*,/$1,/'
 
+# Output the raw times for each command
+echo ""
+echo "command,raw_times"
+jq -r '.results[] | [.command, (.times | join(","))] | join(",")' $TEMP_FILE \
+  | perl -pe 's/^[.]\/calculate_average_(\w+).*?,/$1,/'
+
 rm $TEMP_FILE

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+if [ -z "$1" ]
+  then
+    echo "Usage: evaluate2.sh <fork name> (<fork name 2> ...)"
+    exit 1
+fi
+
+function check_command_installed {
+  if ! [ -x "$(command -v $1)" ]; then
+    echo "Error: $1 is not installed." >&2
+    exit 1
+  fi
+}
+check_command_installed java
+check_command_installed mvn
+check_command_installed hyperfine
+check_command_installed jq
+
+set -o xtrace
+
+java --version
+
+mvn --quiet clean verify
+
+rm -f measurements.txt
+ln -s measurements_1B.txt measurements.txt
+
+set +o xtrace
+
+echo ""
+TEMP_FILE=$(mktemp)
+HYPERFINE_OPTS="--warmup 1 --runs 5 --export-json $TEMP_FILE"
+# For debugging:
+# HYPERFINE_OPTS="$HYPERFINE_OPTS --show-output"
+
+# Prepare commands for running benchmarks for each of the forks
+forks=()
+for fork in "$@"; do
+    forks+=("./calculate_average_$fork.sh 2>&1")
+done
+
+# Use hyperfine to run the benchmarks for each fork
+hyperfine $HYPERFINE_OPTS "${forks[@]}"
+
+# The slowest and the fastest runs are discarded
+# The mean value of the remaining three runs is the result for that contender
+echo ""
+echo "command,trimmed_mean"
+jq -r '.results[] | [ .command, ((.times | sort) | .[1:-1] | add / length) ] | join(",")' $TEMP_FILE \
+  | perl -pe 's/^[.]\/calculate_average_(\w+).*,/$1,/'
+
+rm $TEMP_FILE

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -61,13 +61,13 @@ hyperfine $HYPERFINE_OPTS "${forks[@]}"
 # The slowest and the fastest runs are discarded
 # The mean value of the remaining three runs is the result for that contender
 echo ""
-echo "command,trimmed_mean"
+echo "fork,trimmed_mean"
 jq -r '.results[] | [ .command, ((.times | sort) | .[1:-1] | add / length) ] | join(",")' $TEMP_FILE \
   | perl -pe 's/^[.]\/calculate_average_(\w+).*,/$1,/'
 
 # Output the raw times for each command
 echo ""
-echo "command,raw_times"
+echo "fork,raw_times"
 jq -r '.results[] | [.command, (.times | join(","))] | join(",")' $TEMP_FILE \
   | perl -pe 's/^[.]\/calculate_average_(\w+).*?,/$1,/'
 

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -183,11 +183,12 @@ for fork in "$@"; do
 done
 echo ""
 
-# Apped $fork-$filetimestamp-timing.json to $fork-$filetimestamp.out
-cat $fork-$filetimestamp-timing.json >> $fork-$filetimestamp.out
-rm $fork-$filetimestamp-timing.json
-
+# Finalize .out files
 echo "Raw results saved to file(s):"
 for fork in "$@"; do
+  # Append $fork-$filetimestamp-timing.json to $fork-$filetimestamp.out and rm $fork-$filetimestamp-timing.json
+  cat $fork-$filetimestamp-timing.json >> $fork-$filetimestamp.out
+  rm $fork-$filetimestamp-timing.json
+
   echo "  $fork-$filetimestamp.out"
 done

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -69,7 +69,17 @@ for fork in "$@"; do
   HYPERFINE_OPTS="--warmup 0 --runs 5 --export-json $fork-$filetimestamp.out"
   # For debugging:
   # HYPERFINE_OPTS="$HYPERFINE_OPTS --show-output"
-  hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
+
+  # check if this script is running on a Linux box
+  if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    check_command_installed numactl
+
+    # Linux platform
+    # prepend this with numactl --physcpubind=0-7 for running it only with 8 cores
+    numactl --physcpubind=0-7 hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
+  else
+    hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
+  fi
 done
 
 # Print the 'Summary' in bold and white

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -84,6 +84,8 @@ for fork in "$@"; do
   # Use hyperfine to run the benchmarks for each fork
   HYPERFINE_OPTS="--warmup 1 --runs 5 --export-json $fork-$filetimestamp-timing.json --output ./$fork-$filetimestamp.out"
 
+  set +e # we don't want hyperfine or diff failing on 1 fork to exit the script early
+
   # check if this script is running on a Linux box
   if [ "$(uname -s)" == "Linux" ]; then
     check_command_installed numactl
@@ -96,7 +98,6 @@ for fork in "$@"; do
   fi
 
   # Verify output
-  set +e
   diff <(grep Hamburg $fork-$filetimestamp.out) <(grep Hamburg out_expected.txt) > /dev/null
   if [ $? -ne 0 ]; then
     echo ""

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -25,6 +25,15 @@ if [ -z "$1" ]
     exit 1
 fi
 
+BOLD_WHITE='\033[1;37m'
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+PURPLE='\033[0;35m'
+BOLD_RED='\033[1;31m'
+RED='\033[0;31m'
+BOLD_YELLOW='\033[1;33m'
+RESET='\033[0m' # No Color
+
 function check_command_installed {
   if ! [ -x "$(command -v $1)" ]; then
     echo "Error: $1 is not installed." >&2
@@ -35,6 +44,20 @@ function check_command_installed {
 check_command_installed java
 check_command_installed hyperfine
 check_command_installed jq
+
+# Check if SMT is enabled (we want it disabled)
+if [ -f "/sys/devices/system/cpu/smt/active" ]; then
+  if [ "$(cat /sys/devices/system/cpu/smt/active)" != "0" ]; then
+    echo -e "${BOLD_YELLOW}WARNING${RESET} SMT is enabled"
+  fi
+fi
+
+# Check if Turbo Boost is enabled (we want it disabled)
+if [ -f "/sys/devices/system/cpu/cpufreq/boost" ]; then
+  if [ "$(cat /sys/devices/system/cpu/cpufreq/boost)" != "0" ]; then
+    echo -e "${BOLD_YELLOW}WARNING${RESET} Turbo Boost is enabled"
+  fi
+fi
 
 set -o xtrace
 
@@ -48,14 +71,6 @@ ln -s measurements_1B.txt measurements.txt
 set +o xtrace
 
 echo ""
-
-BOLD_WHITE='\033[1;37m'
-CYAN='\033[0;36m'
-GREEN='\033[0;32m'
-PURPLE='\033[0;35m'
-BOLD_RED='\033[1;31m'
-RED='\033[0;31m'
-RESET='\033[0m' # No Color
 
 # check if out_expected.txt exists
 if [ ! -f "out_expected.txt" ]; then

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -66,7 +66,7 @@ for fork in "$@"; do
   fi
 
   # Use hyperfine to run the benchmarks for each fork
-  HYPERFINE_OPTS="--warmup 0 --runs 5 --export-json $fork-$filetimestamp.out"
+  HYPERFINE_OPTS="--warmup 1 --runs 5 --export-json $fork-$filetimestamp.out"
   # For debugging:
   # HYPERFINE_OPTS="$HYPERFINE_OPTS --show-output"
 


### PR DESCRIPTION
From #105 

For lack of a better name, I called this script `evaluate2.sh`

```bash
$ ./evaluate2.sh
Usage: evaluate2.sh <fork name> (<fork name 2> ...)
```

<img width="896" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/f7c0e230-e838-49a2-9cf9-3299e9fe31e5">

