### PR TITLE
My second attempt

### DIFF
--- a/calculate_average_merykitty.sh
+++ b/calculate_average_merykitty.sh
@@ -16,5 +16,5 @@
 #
 
 
-JAVA_OPTS="--enable-preview --add-modules=jdk.incubator.vector" # -XX:+UnlockDiagnosticVMOptions -XX:PrintAssemblyOptions=intel -XX:CompileCommand=print,*.CalculateAverage_merykitty::iterate"
+JAVA_OPTS="--enable-preview --add-modules=jdk.incubator.vector -XX:-TieredCompilation" # -XX:+UnlockDiagnosticVMOptions -XX:PrintAssemblyOptions=intel -XX:CompileCommand=print,*.CalculateAverage_merykitty::iterate"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_merykitty


### PR DESCRIPTION
I'm getting competitive so this is another iteration. Since we are not bounded by loads, change the algorithm to have 1 vector for each line, this simplifies the following calculations a little bit. The result is about 5 - 10% reduction in execution time, with IPC pushed to 1.9 and branch misprediction reduced by nearly a half.

Please review and evaluate, thanks a lot.

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time: 1.4 - 1.6s (14.92user 1.02system 0:01.46elapsed 1091%CPU)
* Execution time of reference implementation: 106s
