### PR TITLE
More optimizations for ebarlas submission

### DIFF
--- a/calculate_average_ebarlas.sh
+++ b/calculate_average_ebarlas.sh
@@ -16,4 +16,4 @@
 #
 
 JAVA_OPTS=""
-java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ebarlas measurements.txt 8
+java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ebarlas


### PR DESCRIPTION
#### Check List:
- [x ] Tests pass (`./test.sh ebarlas` shows no differences between expected and actual outputs)
- [ x] All formatting changes by the build are committed
- [ x] Your launch script is named `calculate_average_ebarlas.sh` (make sure to match casing of your GH user name) and is executable
- [x ] Output matches that of `calculate_average_baseline.sh`
* Execution time: 5.9s on `c5.2xlarge` down from 6.8s (13% reduction)
* Execution time of reference implementation: 3m59s

Execution time on CCX33 VM down from 5.7s to 4.7s (18% reduction)