### PR TITLE
Second submission by flippingbits - 50% performance improvement

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_flippingbits.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_flippingbits.java
@@ -33,7 +33,7 @@ public class CalculateAverage_flippingbits {
 
     private static final String FILE = "./measurements.txt";
 
-    private static final long CHUNK_SIZE = 100 * 1024 * 1024; // 100 MB
+    private static final long CHUNK_SIZE = 10 * 1024 * 1024; // 10 MB
 
     private static final int SIMD_LANE_LENGTH = ShortVector.SPECIES_MAX.length();
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_flippingbits.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_flippingbits.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Approach:


### PR DESCRIPTION
Hi @gunnarmorling,

Thank you so much for taking care of this amazing challenge. I worked on the parsing of the station names and measurement values, resulting in a performance improvement of around 50% compared to the first revision of my submission measured on my local machine. May I ask you to run my updated submission on the evaluation environment?

Thanks,
Stefan

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time:
```
real	0m5.081s
user	0m39.459s
sys	0m2.815s
```
* Execution time of reference implementation:
```
real	3m15.857s
user	3m10.493s
sys	0m5.456s
```