### PR TITLE
evaluate2.sh improvements - leaderboard, default SDK

### DIFF
--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -34,6 +34,8 @@ RED='\033[0;31m'
 BOLD_YELLOW='\033[1;33m'
 RESET='\033[0m' # No Color
 
+DEFAULT_JAVA_VERSION="21.0.1-open"
+
 function check_command_installed {
   if ! [ -x "$(command -v $1)" ]; then
     echo "Error: $1 is not installed." >&2
@@ -56,9 +58,9 @@ fi
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 # 3. make sure the default java version is installed
-if [ ! -d "$HOME/.sdkman/candidates/java/21.0.1-open" ]; then
-  echo "+ sdk install java 21.0.1-open"
-  sdk install java 21.0.1-open
+if [ ! -d "$HOME/.sdkman/candidates/java/$DEFAULT_JAVA_VERSION" ]; then
+  echo "+ sdk install java $DEFAULT_JAVA_VERSION"
+  sdk install java $DEFAULT_JAVA_VERSION
 fi
 
 # 4. Install missing SDK java versions in any of the prepare_*.sh scripts for the provided forks
@@ -118,8 +120,8 @@ for fork in "$@"; do
     echo "+ source ./prepare_$fork.sh"
     source "./prepare_$fork.sh"
   else
-    echo "+ sdk use java 21.0.1-open"
-    sdk use java 21.0.1-open
+    echo "+ sdk use java $DEFAULT_JAVA_VERSION"
+    sdk use java $DEFAULT_JAVA_VERSION
   fi
 
   # Optional additional build steps

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -51,18 +51,20 @@ if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
     echo "Error: sdkman is not installed." >&2
     exit 1
 fi
+
+# 2. Init sdkman in this script
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-# 2. make sure the default java version is installed
+# 3. make sure the default java version is installed
 if [ ! -d "$HOME/.sdkman/candidates/java/21.0.1-open" ]; then
   echo "+ sdk install java 21.0.1-open"
   sdk install java 21.0.1-open
 fi
 
-# 3. Install missing SDK java versions in any of the prepare_*.sh scripts for the provided forks
+# 4. Install missing SDK java versions in any of the prepare_*.sh scripts for the provided forks
 for fork in "$@"; do
   if [ -f "./prepare_$fork.sh" ]; then
-    grep -h "^sdk use" "./prepare_$fork.sh" | cut -d' ' -f4 | sort | uniq | while read -r version; do
+    grep -h "^sdk use" "./prepare_$fork.sh" | cut -d' ' -f4 | while read -r version; do
       if [ ! -d "$HOME/.sdkman/candidates/java/$version" ]; then
         echo "+ sdk install java $version"
         sdk install java $version

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -88,6 +88,10 @@ for fork in "$@"; do
   if [ -f "./prepare_$fork.sh" ]; then
     echo "+ source ./prepare_$fork.sh"
     source "./prepare_$fork.sh"
+  else
+    echo "+ sdk use java 21.0.1-open"
+    source "$HOME/.sdkman/bin/sdkman-init.sh"
+    sdk use java 21.0.1-open
   fi
 
   # Optional additional build steps
@@ -161,8 +165,8 @@ for fork in "$@"; do
 
   trimmed_mean=$(jq -r '.results[0].times | .[1:-1] | add / length' $fork-$filetimestamp-timing.json)
 
-  # Read java version from prepare_$fork.sh if it exists
-  java_version="unknown"
+  # Read java version from prepare_$fork.sh if it exists, otherwise assume 21.0.1-open
+  java_version="21.0.1-open"
   if [ -f "./prepare_$fork.sh" ]; then
     java_version=$(grep "sdk use java" ./prepare_$fork.sh | cut -d' ' -f4)
   fi

--- a/github_users.txt
+++ b/github_users.txt
@@ -38,3 +38,13 @@ padreati;Aurelian Tutuianu
 palmr;Nick Palmer
 rby;Ramzi Ben Yahya
 richardstartin;Richard Startin
+spullara;Sam Pullara
+royvanrijn;Roy van Rijn
+seijikun;Markus Ebner
+semotpan;Serghei Motpan
+thomaswue;Thomas Wuerthinger
+truelive;Roman Schweitzer
+twobiers;Tobi
+yavuztas;Yavuz Tas
+yehwankim23;김예환 Ye-Hwan Kim (Sam)
+hundredwatt;Jason Nochlin

--- a/github_users.txt
+++ b/github_users.txt
@@ -1,0 +1,40 @@
+Ujjwalbharti;Ujjwal Bharti
+abfrmblr;Abhilash
+ags313;ags
+anandmattikopp;twohardthings
+armandino;Arman Sharif
+artpar;Parth Mudgal
+asun;Alan Sun
+bjhara;Hampus
+coolmineman;Cool_Mineman
+criccomini;Chris Riccomini
+davecom;David Kopec
+davery22;Daniel Avery
+ddimtirov;Dimitar Dimitrov
+ebarlas;Elliot Barlas
+entangled90;Carlo
+fatroom;Roman Romanchuk
+felix19350;Bruno Félix
+filiphr;Filip Hrisafov
+flippingbits;Stefan Sprenger
+fragmede;Samson
+gabrielreid;Gabriel Reid
+hchiorean;Horia Chiorean
+imrafaelmerino;Rafael Merino García
+isolgpus;Jamie Stansfield
+iziamos;John Ziamos
+jgrateron;Jairo Graterón
+jotschi;Johannes Schüth
+kevinmcmurtrie;Kevin McMurtrie
+kgeri;Gergely Kiss
+khmarbaise;Karl Heinz Marbaise
+kuduwa-keshavram;Keshavram Kuduwa
+merykitty;Quan Anh Mai
+moysesb;Moysés Borges Furtado
+mudit-saxena;Mudit Saxena
+nstng;Nils Semmelrock
+obourgain;Olivier Bourgain
+padreati;Aurelian Tutuianu
+palmr;Nick Palmer
+rby;Ramzi Ben Yahya
+richardstartin;Richard Startin

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
                 <exclude>**/measurements*.txt</exclude>
                 <exclude>**/measurements*.out</exclude>
                 <exclude>out_expected.txt</exclude>
+                <exclude>github_users.txt</exclude>
               </excludes>
             </configuration>
             <executions>


### PR DESCRIPTION
Closes #270 

- [x] Sort leaderboard by time
- [x] Show name of Github user (maybe with a local cache 😉)
- [x] we could just fake it by saying "GraalVM native binary" when the additional build script
- [x]  reset the JDK to the default (21.0.1-open) when no prepare script is provided

Example leaderboard output (used 100m rows instead of 1b to save time, that's why everyone looks so fast here 😉)

<img width="1462" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/6d97c377-a7cd-4186-92fb-a926ae10491a">
