### PR TITLE
evaluate2.sh: validate fork names and fix grep bug

### DIFF
--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -82,7 +82,6 @@ for fork in "$@"; do
     done || true # grep returns exit code 1 when no match, `|| true` prevents the script from exiting early
   fi
 done
-echo "SUCCESS"
 ## END - SDKMAN Setup
 
 # Check if SMT is enabled (we want it disabled)

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -47,6 +47,14 @@ check_command_installed java
 check_command_installed hyperfine
 check_command_installed jq
 
+# Validate that ./calculate_average_<fork>.sh exists for each fork
+for fork in "$@"; do
+  if [ ! -f "./calculate_average_$fork.sh" ]; then
+    echo "Error: ./calculate_average_$fork.sh does not exist." >&2
+    exit 1
+  fi
+done
+
 ## SDKMAN Setup
 # 1. Custom check for sdkman installed; not sure why check_command_installed doesn't detect it properly
 if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -71,9 +71,10 @@ for fork in "$@"; do
         echo "+ sdk install java $version"
         sdk install java $version
       fi
-    done
+    done || true # grep returns exit code 1 when no match, `|| true` prevents the script from exiting early
   fi
 done
+echo "SUCCESS"
 ## END - SDKMAN Setup
 
 # Check if SMT is enabled (we want it disabled)


### PR DESCRIPTION
Call #283

- [x] Validate fork names
- [x] In block that installs SDKs, grep returns exit code 1 when no match. Add `|| true` to prevent the script from exiting early.

<img width="390" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/378e5f33-bc1e-4527-beb1-c40da024592b">
