### PR TITLE
evaluate2.sh: catch hyperfine command failed

### DIFF
--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -153,6 +153,11 @@ for fork in "$@"; do
   else
     hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
   fi
+  # Catch hyperfine command failed
+  if [ $? -ne 0 ]; then
+    failed+=("$fork")
+    echo ""
+  fi
 
   # Verify output
   diff <(grep Hamburg $fork-$filetimestamp.out) <(grep Hamburg out_expected.txt) > /dev/null


### PR DESCRIPTION
@gunnarmorling FYI this runs all forks:

```sh
./evaluate2.sh `ls -1 ./calculate_average_*.sh | cut -d_ -f3 | cut -d. -f1`
```

I tested this (using a tiny measurements.txt script + adding `timeout 1` before `./calculate_average_.sh`) and found another bug that breaks the Leaderboard when any of the hyperfine commands failed.

With this fix, the script works on my machine for all forks!

--

If you want to try running all forks on the eval machine, I recommend adding `timeout` like this to catch forks that hang forever:
```bash
    numactl --physcpubind=0-7 hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
```

to 

```bash
    timeout 600 numactl --physcpubind=0-7 hyperfine $HYPERFINE_OPTS "./calculate_average_$fork.sh 2>&1"
```

When a command fails (via timeout or other failure caught by hyperfine), this message appears and the $fork is excluded from the Summary/Leaderboard same as if the output did not match:

<img width="941" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/9396b6db-068a-46f7-927d-cf58de21e90e">
