### PR TITLE
Second attempt without going the simd route. Maybe a 70% improvement with an "out there" version of a hashmap.

### DIFF
--- a/calculate_average_iziamos.sh
+++ b/calculate_average_iziamos.sh
@@ -15,6 +15,5 @@
 #  limitations under the License.
 #
 
-
-JAVA_OPTS="--enable-preview"
+JAVA_OPTS="--enable-preview --add-modules=jdk.incubator.vector -Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0 -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms16m -Xmx16m -XX:-AlwaysPreTouch -XX:-TieredCompilation -XX:CICompilerCount=1"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_iziamos


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time: sub 0:01.30 on my machine
* Execution time of reference implementation: 1:35.20

this:           24.41user 0.53system 0:01.26elapsed 1978%CPU (0avgtext+0avgdata 13728720maxresident)k
merykitty: 22.03user 0.51system 0:01.16elapsed 1929%CPU (0avgtext+0avgdata 13551768maxresident)k
obourgain 26.69user 0.43system 0:01.30elapsed 2084%CPU (0avgtext+0avgdata 13581888maxresident)k

Thoughts:
I wanted to try something abit crazier without going down the SIMD/SWAR route:
1. This was actually not too hard to implement
2. Word aligning structs doesn't really affect performance. (idk why i thought it might, not like you'll get false sharing or something here.)
3. This has been an amazing opportunity to try out all the Java stuff you cant use at work yet (memory segments, vectors etc)
5. My 13700K seems to show weird behaviour as seen below:

  21,731,224      cpu_atom/branch-misses/          #    1.16% of all branches             (19.99%)
             TopdownL1 (cpu_core)                 #     41.0 %  tma_backend_bound      
                                                  #     15.9 %  tma_bad_speculation    
                                                  #     25.2 %  tma_frontend_bound     
                                                  #     17.9 %  tma_retiring             (52.55%)
             TopdownL1 (cpu_atom)                
                                                  #     20.4 %  tma_bad_speculation      (18.18%)
                                                  #     18.3 %  tma_frontend_bound       (17.38%)
                                                  #     31.2 %  tma_backend_bound      
                                                  #     31.2 %  tma_backend_bound_aux    (15.98%)
                                                  #     19.9 %  tma_retiring             (13.21%)

Atom is _always_ worse at speculation than whatever the normal i7 core is. Would be cool to see what the behaviour on the server is.

The atom cores make prediction difficult compared to the server but my (always optimistic) prediction is that this will run sub 5.5 second there (more my realistic guess is 7 :) ).


I've already said this but thanks for setting this up it's been an amazing motivator to try the new Java features.
