### PR TITLE
evaluate2.sh: Check output of warmup run and abort early if failed

### DIFF
--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -136,26 +136,29 @@ fi
 # Run tests and benchmark for each fork
 filetimestamp=$(date  +"%Y%m%d%H%M%S") # same for all fork.out files from this run
 failed=()
+test_output=$(mktemp)
 for fork in "$@"; do
   set +e # we don't want prepare.sh, test.sh or hyperfine failing on 1 fork to exit the script early
 
   # Run the test suite
-  print_and_execute $TIMEOUT ./test.sh $fork > /dev/null
+  print_and_execute $TIMEOUT ./test.sh $fork | tee $test_output > /dev/null 2>&1
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""
     echo -e "${BOLD_RED}FAILURE${RESET}: ./test.sh $fork failed"
+    cat $test_output
     echo ""
 
     continue
   fi
 
   # Run the test on $MEASUREMENTS_FILE; this serves as the warmup
-  print_and_execute $TIMEOUT ./test.sh $fork $MEASUREMENTS_FILE > /dev/null
+  print_and_execute $TIMEOUT ./test.sh $fork $MEASUREMENTS_FILE | tee $test_output > /dev/null 2>&1
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""
     echo -e "${BOLD_RED}FAILURE${RESET}: ./test.sh $fork $MEASUREMENTS_FILE failed"
+    cat $test_output
     echo ""
 
     continue
@@ -194,6 +197,7 @@ for fork in "$@"; do
   fi
 done
 set -e
+rm $test_output
 
 # Summary
 echo -e "${BOLD_WHITE}Summary${RESET}"

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -126,6 +126,8 @@ fi
 filetimestamp=$(date  +"%Y%m%d%H%M%S") # same for all fork.out files from this run
 failed=()
 for fork in "$@"; do
+  set -e
+  
   # Use prepare script to invoke SDKMAN
   if [ -f "./prepare_$fork.sh" ]; then
     print_and_execute source "./prepare_$fork.sh"
@@ -133,7 +135,7 @@ for fork in "$@"; do
     print_and_execute sdk use java $DEFAULT_JAVA_VERSION
   fi
 
-  set +e # we don't want hyperfine or diff failing on 1 fork to exit the script early
+  set +e # we don't want test.sh or hyperfine failing on 1 fork to exit the script early
 
   # Save output of test.sh to a temporary pipe
   # This is needed because test.sh deletes measurements.txt
@@ -186,10 +188,8 @@ for fork in "$@"; do
     failed+=("$fork")
     # Hyperfine already prints the error message
     echo ""
-    continue;
+    continue
   fi
-
-  set -e
 done
 
 # Summary

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -140,7 +140,7 @@ for fork in "$@"; do
   set +e # we don't want prepare.sh, test.sh or hyperfine failing on 1 fork to exit the script early
 
   # Run the test suite
-  print_and_execute $TIMEOUT ./test.sh --quiet $fork
+  print_and_execute $TIMEOUT ./test.sh $fork > /dev/null
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""
@@ -151,7 +151,7 @@ for fork in "$@"; do
   fi
 
   # Run the test on $MEASUREMENTS_FILE; this serves as the warmup
-  print_and_execute $TIMEOUT ./test.sh --quiet $fork $MEASUREMENTS_FILE
+  print_and_execute $TIMEOUT ./test.sh $fork $MEASUREMENTS_FILE > /dev/null
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -283,9 +283,12 @@ rm $leaderboard_temp_file
 # Finalize .out files
 echo "Raw results saved to file(s):"
 for fork in "$@"; do
-  # Append $fork-$filetimestamp-timing.json to $fork-$filetimestamp.out and rm $fork-$filetimestamp-timing.json
-  cat $fork-$filetimestamp-timing.json >> $fork-$filetimestamp.out
-  rm $fork-$filetimestamp-timing.json
+  if [ -f "$fork-$filetimestamp-timing.json" ]; then
+      cat $fork-$filetimestamp-timing.json >> $fork-$filetimestamp.out
+      rm $fork-$filetimestamp-timing.json
+  fi
 
-  echo "  $fork-$filetimestamp.out"
+  if [ -f "$fork-$filetimestamp.out" ]; then
+    echo "  $fork-$filetimestamp.out"
+  fi
 done

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -107,9 +107,9 @@ print_and_execute ./mvnw --quiet clean verify
 
 echo ""
 
-# check if out_expected.txt exists
-if [ ! -f "out_expected.txt" ]; then
-  echo "Error: out_expected.txt does not exist." >&2
+# check if measurements_1B.out exists
+if [ ! -f "measurements_1B.out" ]; then
+  echo -e "${BOLD_RED}ERROR${RESET}: measurements_1B.out does not exist." >&2
   echo "Please create it with:"
   echo ""
   echo "  ./calculate_average_baseline.sh > measurements_1B.out"

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -56,7 +56,7 @@ check_command_installed bc
 # Validate that ./calculate_average_<fork>.sh exists for each fork
 for fork in "$@"; do
   if [ ! -f "./calculate_average_$fork.sh" ]; then
-    echo "Error: ./calculate_average_$fork.sh does not exist." >&2
+    echo -e "${BOLD_RED}ERROR${RESET}: ./calculate_average_$fork.sh does not exist." >&2
     exit 1
   fi
 done
@@ -64,7 +64,7 @@ done
 ## SDKMAN Setup
 # 1. Custom check for sdkman installed; not sure why check_command_installed doesn't detect it properly
 if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
-    echo "Error: sdkman is not installed." >&2
+     echo -e "${BOLD_RED}ERROR${RESET}: sdkman is not installed." >&2
     exit 1
 fi
 
@@ -111,7 +111,9 @@ echo ""
 if [ ! -f "out_expected.txt" ]; then
   echo "Error: out_expected.txt does not exist." >&2
   echo "Please create it with:"
-  echo "  ./calculate_average_baseline.sh > out_expected.txt"
+  echo ""
+  echo "  ./calculate_average_baseline.sh > measurements_1B.out"
+  echo ""
   exit 1
 fi
 

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -44,7 +44,7 @@ function check_command_installed {
 }
 
 function print_and_execute() {
-  echo "+ $@"
+  echo "+ $@" >&2
   "$@"
 }
 
@@ -104,6 +104,9 @@ fi
 
 print_and_execute java --version
 print_and_execute ./mvnw --quiet clean verify
+
+print_and_execute rm -f measurements.txt
+print_and_execute ln -s $MEASUREMENTS_FILE measurements.txt
 
 echo ""
 

--- a/evaluate2.sh
+++ b/evaluate2.sh
@@ -149,7 +149,7 @@ for fork in "$@"; do
   set +e # we don't want test.sh or hyperfine failing on 1 fork to exit the script early
 
   # Run the test suite
-  print_and_execute $TIMEOUT ./test.sh $fork > /dev/null
+  print_and_execute $TIMEOUT ./test.sh --quiet $fork
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""
@@ -160,7 +160,7 @@ for fork in "$@"; do
   fi
 
   # Run the test on $MEASUREMENTS_FILE; this serves as the warmup
-  print_and_execute $TIMEOUT ./test.sh $fork $MEASUREMENTS_FILE > /dev/null
+  print_and_execute $TIMEOUT ./test.sh --quiet $fork $MEASUREMENTS_FILE
   if [ $? -ne 0 ]; then
     failed+=("$fork")
     echo ""

--- a/test.sh
+++ b/test.sh
@@ -18,44 +18,29 @@
 set -euo pipefail
 
 DEFAULT_INPUT="src/test/resources/samples/*.txt"
+FORK=${1:-""}
+INPUT=${2:-$DEFAULT_INPUT}
 
-if [ "$#" -eq 0 ] || [ "$#" -gt 3 ] || [ "$1" == "-h" ]; then
+if [ "$#" -eq 0 ] || [ "$#" -gt 2 ] || [ "$FORK" = "-h" ]; then
   echo "Usage: ./test.sh <fork name> [input file pattern]"
   echo
   echo "For each test sample matching <input file pattern> (default '$DEFAULT_INPUT')"
   echo "runs <fork name> implementation and diffs the result with the expected output."
   echo "Note that optional <input file pattern> should be quoted if contains wild cards."
-  echo "Use optional flag --quiet to suppress output."
   echo
   echo "Examples:"
   echo "./test.sh baseline"
   echo "./test.sh baseline src/test/resources/samples/measurements-1.txt"
   echo "./test.sh baseline 'src/test/resources/samples/measurements-*.txt'"
-  echo "./test.sh --quiet baseline"
   exit 1
 fi
 
-QUIET=false
-if [ "$1" == "--quiet" ]; then
-  QUIET=true
-  shift
-fi
-
-FORK=${1:-""}
-INPUT=${2:-$DEFAULT_INPUT}
-
 if [ -f "./prepare_$FORK.sh" ]; then
-  if [ $QUIET == true ]; then
-    "./prepare_$FORK.sh"
-  else
-    "./prepare_$FORK.sh" > /dev/null
-  fi
+  "./prepare_$FORK.sh"
 fi
 
 for sample in $(ls $INPUT); do
-  if [ $QUIET != true ]; then
-    echo "Validating calculate_average_$FORK.sh -- $sample"
-  fi
+  echo "Validating calculate_average_$FORK.sh -- $sample"
 
   rm -f measurements.txt
   ln -s $sample measurements.txt

--- a/test.sh
+++ b/test.sh
@@ -45,18 +45,7 @@ for sample in $(ls $INPUT); do
   rm -f measurements.txt
   ln -s $sample measurements.txt
 
-  if command -v git; then
-    # git version must be 2.43 or newer to use \`git diff\` with process substitution
-    # Source: https://stackoverflow.com/questions/22706714/why-does-git-diff-not-work-with-process-substitution
-    # In the future, we can do this instead of a temp file:
-    #   git diff --no-index --word-diff <("./calculate_average_$FORK.sh") ${sample%.txt}
-    temp_file=$(mktemp)
-    "./calculate_average_$FORK.sh" > $temp_file
-    git diff --no-index --word-diff $temp_file ${sample%.txt}.out
-    rm $temp_file
-  else
-    diff <("./calculate_average_$FORK.sh") ${sample%.txt}.out
-  fi
+  diff <("./calculate_average_$FORK.sh" | ./tocsv.sh) <(./tocsv.sh < ${sample%.txt}.out)
 done
 
 rm measurements.txt

--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,18 @@ for sample in $(ls $INPUT); do
   rm -f measurements.txt
   ln -s $sample measurements.txt
 
-  diff <("./calculate_average_$FORK.sh") ${sample%.txt}.out
+  if command -v git; then
+    # git version must be 2.43 or newer to use \`git diff\` with process substitution
+    # Source: https://stackoverflow.com/questions/22706714/why-does-git-diff-not-work-with-process-substitution
+    # In the future, we can do this instead of a temp file:
+    #   git diff --no-index --word-diff <("./calculate_average_$FORK.sh") ${sample%.txt}
+    temp_file=$(mktemp)
+    "./calculate_average_$FORK.sh" > $temp_file
+    git diff --no-index --word-diff $temp_file ${sample%.txt}.out
+    rm $temp_file
+  else
+    diff <("./calculate_average_$FORK.sh") ${sample%.txt}.out
+  fi
 done
 
 rm measurements.txt

--- a/test.sh
+++ b/test.sh
@@ -18,29 +18,44 @@
 set -euo pipefail
 
 DEFAULT_INPUT="src/test/resources/samples/*.txt"
-FORK=${1:-""}
-INPUT=${2:-$DEFAULT_INPUT}
 
-if [ "$#" -eq 0 ] || [ "$#" -gt 2 ] || [ "$FORK" = "-h" ]; then
+if [ "$#" -eq 0 ] || [ "$#" -gt 3 ] || [ "$1" == "-h" ]; then
   echo "Usage: ./test.sh <fork name> [input file pattern]"
   echo
   echo "For each test sample matching <input file pattern> (default '$DEFAULT_INPUT')"
   echo "runs <fork name> implementation and diffs the result with the expected output."
   echo "Note that optional <input file pattern> should be quoted if contains wild cards."
+  echo "Use optional flag --quiet to suppress output."
   echo
   echo "Examples:"
   echo "./test.sh baseline"
   echo "./test.sh baseline src/test/resources/samples/measurements-1.txt"
   echo "./test.sh baseline 'src/test/resources/samples/measurements-*.txt'"
+  echo "./test.sh --quiet baseline"
   exit 1
 fi
 
+QUIET=false
+if [ "$1" == "--quiet" ]; then
+  QUIET=true
+  shift
+fi
+
+FORK=${1:-""}
+INPUT=${2:-$DEFAULT_INPUT}
+
 if [ -f "./prepare_$FORK.sh" ]; then
-  "./prepare_$FORK.sh"
+  if [ $QUIET == true ]; then
+    "./prepare_$FORK.sh"
+  else
+    "./prepare_$FORK.sh" > /dev/null
+  fi
 fi
 
 for sample in $(ls $INPUT); do
-  echo "Validating calculate_average_$FORK.sh -- $sample"
+  if [ $QUIET != true ]; then
+    echo "Validating calculate_average_$FORK.sh -- $sample"
+  fi
 
   rm -f measurements.txt
   ln -s $sample measurements.txt


### PR DESCRIPTION
Closes #313 

- [x] Change instructions that create `out_expected.txt` to create `measurements_1B.out`
- [x] Run `./test.sh` before hyperfine
- [x] Replace hyperfine warmup with `./test.sh <fork> measurements_1B.txt` and compare its result to measurements_1B.out

## New Output

In screenshot below:
* `hundredwatt` fork passes tests
* `all_bad` fails to pass for all tests
* `bad_1b` passes test.sh default suite, but fails on test file

NOTE: for development purposes, I used a 100m row file and only 3 runs. This is reflected in the screenshot below, but not in this PR's code.

<img width="844" alt="image" src="https://github.com/gunnarmorling/1brc/assets/91577/9bd880b7-90aa-4945-9ef9-a92303894f64">
