### PR TITLE
I optimized my solution:

### DIFF
--- a/calculate_average_yavuztas.sh
+++ b/calculate_average_yavuztas.sh
@@ -15,5 +15,5 @@
 #  limitations under the License.
 #
 
-JAVA_OPTS="-Xms1g -Xmx1g"
+JAVA_OPTS="-Xms128m -Xmx128m -XX:MaxGCPauseMillis=1 -XX:-AlwaysPreTouch -XX:+UseSerialGC --enable-preview"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_yavuztas


### PR DESCRIPTION
 - Eliminate redundant object creations in between
 - Custom HashMap on purpose - Inspired by @spullara
 - More performant temperature parsing - Inspired by @yemreinci
 - JVM tweaks, decreased heap memory, and remove AlwaysPreTouch

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time: ~3s
* Execution time of reference implementation: ~3m.22s

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that you are expecting to run in 30 seconds or less.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
