### PR TITLE
Use bash in prepare scripts

### DIFF
--- a/prepare_hundredwatt.sh
+++ b/prepare_hundredwatt.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #
@@ -14,7 +14,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-
 
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 sdk use java 21.0.1-graal

--- a/prepare_kuduwa-keshavram.sh
+++ b/prepare_kuduwa-keshavram.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #

--- a/prepare_mtopolnik.sh
+++ b/prepare_mtopolnik.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #

--- a/prepare_ricardopieper.sh
+++ b/prepare_ricardopieper.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #

--- a/prepare_roman-r-m.sh
+++ b/prepare_roman-r-m.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #


### PR DESCRIPTION
Prepare scripts that use `#!/bin/sh` and
`source "$HOME/.sdkman/bin/sdkman-init.sh"`
fail on systems where `sh` is not `bash`,
e.g. on Ubuntu it is `dash` which has not `source`.
