### PR TITLE
Third attempt CalculateAverage_zerninv

### DIFF
--- a/calculate_average_zerninv.sh
+++ b/calculate_average_zerninv.sh
@@ -15,5 +15,5 @@
 #  limitations under the License.
 #
 
-JAVA_OPTS=""
+JAVA_OPTS="--enable-preview"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_zerninv


### PR DESCRIPTION
introduce unsafe

#### Check List:
- [x] Tests pass (`./test.sh zerninv` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_zerninv.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time: 16s
* Execution time of reference implementation: 6m
