### PR TITLE
Performance improvements for ricardopieper

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ricardopieper.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ricardopieper.java
@@ -287,10 +287,10 @@ public class CalculateAverage_ricardopieper {
         public int count;
 
         public StationMeasurements(
-                long min,
-                long max,
-                long sum,
-                int count) {
+                                   long min,
+                                   long max,
+                                   long sum,
+                                   int count) {
             this.min = min;
             this.max = max;
             this.sum = sum;

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ricardopieper.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ricardopieper.java
@@ -23,6 +23,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 /*
@@ -36,6 +39,8 @@ import java.util.*;
   - @royvanrijn again for the parse int only and /10 in the very end
   - @flippingbits for the idea of not calling getLong on mmaped file directly, get a big chunk into memory instead
         - Maybe on linux it's actually faster?
+        - Confirmed: mmap is faster at least on Windows.
+
   - OpenAI / ChatGPT for the actual bit twiddling idea for finding a character, it couldn't explain it so I did my best
     (Turns out @royvanrijn had the same idea)
 
@@ -45,14 +50,235 @@ import java.util.*;
   ~5% boost for me.
 
 
- Todo:
-  - The final aggregation of results is taking around 1 whole second to complete. Improve it.
+Perf tracking (on my Windows machine):
+
+    1: ~11s
+    2: 9.77s
+    3: 8.0s
+
+ Version 1:
+   - Initial implementation
+
+ Version 2:
+   - Adding multiple ways to read longs from a file, either mmaped or preread.
+   - Perf improvements due do mmap read.
+     On my mac for some reason reading a big chunk is faster, on @royvanrijn's mac the mmap read is faster. Maybe
+     due to M2 having more memory?
+
+     On Linux AWS c6a-4xlarge graalvm 21.0.1:
+       GraalVM:
+         - Preread takes ~11.2 seconds
+         - Mmap takes ~10.7 seconds
+        So it's a bit faster but not much.
+
+ Version 3:
+  - The final aggregation of results was taking around 1 whole second to complete. Instead of adding the string
+  to the TreeMap on every chunk, do it only once in the end when everything is aggregated.
 
  */
 @SuppressWarnings("unchecked")
 public class CalculateAverage_ricardopieper {
-
+    private static final boolean FORCE_PREREAD = false;
+    private static final boolean FORCE_MAPPED = false;
     private static final String FILE = "./measurements.txt";
+
+    public static class ByteSlice {
+        public ByteSlice(int start, int length, byte[] buffer) {
+            this.start = start;
+            this.length = length;
+            this.buffer = buffer;
+        }
+
+        public int start;
+        public int length;
+        public byte[] buffer;
+
+        public OwnedByteSlice copyBytes() {
+            return new OwnedByteSlice(Arrays.copyOfRange(buffer, start, start + length));
+        }
+
+        @Override
+        public int hashCode() {
+            int result = 1;
+            for (int i = start; i < start + length; i++) {
+                result = 31 * result + buffer[i];
+            }
+            return result;
+        }
+
+        // I don't want to override the equals
+        public boolean equalTo(byte[] a2) {
+            if (length != a2.length) {
+                return false;
+            }
+            // I tried all sorts of trickery here,
+            // like comparing first and last before the loop.
+            // It's useless. Maybe slower. Because when strings are the same length
+            // it's a pretty high chance they are the same...
+            for (int i = 0; i < length; i++) {
+                if (buffer[start + i] != a2[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public boolean equalTo(OwnedByteSlice a2) {
+            if (length != a2.bytes.length) {
+                return false;
+            }
+            // I tried all sorts of trickery here,
+            // like comparing first and last before the loop.
+            // It's useless. Maybe slower. Because when strings are the same length
+            // it's a pretty high chance they are the same...
+            for (int i = 0; i < length; i++) {
+                if (buffer[start + i] != a2.bytes[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return new String(buffer, start, length);
+        }
+    }
+
+    public static class OwnedByteSlice {
+        public byte[] bytes;
+
+        public OwnedByteSlice(byte[] bytes) {
+            this.bytes = bytes;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            OwnedByteSlice that = (OwnedByteSlice) o;
+            return Arrays.equals(bytes, that.bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(bytes);
+        }
+
+        @Override
+        public String toString() {
+            return new String(bytes);
+        }
+    }
+
+    interface FileStreamer {
+        long getLong();
+
+        boolean hasRemaining();
+
+        void position(int pos);
+
+        int position();
+
+        ByteSlice getSlice(int start, int length);
+
+    }
+
+    public static abstract class ByteBufferStreamer implements FileStreamer {
+        protected ByteBuffer byteBuffer;
+
+        ByteBufferStreamer() {
+        }
+
+        @Override
+        public boolean hasRemaining() {
+            return this.byteBuffer.hasRemaining();
+        }
+
+        @Override
+        public void position(int pos) {
+            this.byteBuffer.position(pos);
+        }
+
+        @Override
+        public int position() {
+            return this.byteBuffer.position();
+        }
+
+    }
+
+    // Works well in my MacOS laptop
+    static class ChunkPrereader extends ByteBufferStreamer {
+        private final ByteSlice cachedByteSlice;
+
+        public ChunkPrereader(FileChunk chunk) {
+            // this +8 helps to remove a conditional check when calling getLong when there's less than 8 bytes remaining
+            this.byteBuffer = ByteBuffer.allocate(chunk.size + 8);
+            try (var channel = new RandomAccessFile(chunk.path.toString(), "r")) {
+                channel.seek(chunk.start);
+                channel.read(byteBuffer.array(), 0, chunk.size);
+            }
+            catch (Exception e) {
+                // yes bad practice, but idc
+                throw new RuntimeException(e);
+            }
+            byteBuffer.position(0);
+            cachedByteSlice = new ByteSlice(0, 0, byteBuffer.array());
+        }
+
+        @Override
+        public long getLong() {
+            return this.byteBuffer.getLong();
+        }
+
+        @Override
+        public ByteSlice getSlice(int start, int length) {
+            cachedByteSlice.start = start;
+            cachedByteSlice.length = length;
+            return cachedByteSlice;
+        }
+
+    }
+
+    // May be better in other computers
+    static class ChunkMapped extends ByteBufferStreamer {
+        private final ByteSlice cachedByteSlice;
+
+        public ChunkMapped(FileChunk chunk) {
+            try (var fileChannel = FileChannel.open(chunk.path, StandardOpenOption.READ)) {
+                this.byteBuffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, chunk.start, chunk.size);
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            byteBuffer.position(0);
+            cachedByteSlice = new ByteSlice(0, 0, new byte[200]);
+        }
+
+        public long getLong() {
+            if (this.byteBuffer.remaining() >= 8) {
+                return this.byteBuffer.getLong();
+            }
+            else {
+                byte[] longBytes = new byte[8];
+                this.byteBuffer.get(longBytes, 0, this.byteBuffer.remaining());
+                return ByteBuffer.wrap(longBytes).getLong();
+            }
+        }
+
+        @Override
+        public ByteSlice getSlice(int start, int length) {
+            var oldPos = this.byteBuffer.position();
+            this.byteBuffer.position(start);
+            this.byteBuffer.get(this.cachedByteSlice.buffer, 0, length);
+            this.cachedByteSlice.start = 0;
+            this.cachedByteSlice.length = length;
+            this.byteBuffer.position(oldPos);
+            return this.cachedByteSlice;
+        }
+    }
 
     public static final class StationMeasurements {
         public long min;
@@ -61,12 +287,10 @@ public class CalculateAverage_ricardopieper {
         public int count;
 
         public StationMeasurements(
-                                   long min,
-                                   long max,
-                                   long sum,
-                                   int count
-
-        ) {
+                long min,
+                long max,
+                long sum,
+                int count) {
             this.min = min;
             this.max = max;
             this.sum = sum;
@@ -80,6 +304,24 @@ public class CalculateAverage_ricardopieper {
             var max = String.format("%.1f", (double) this.max / 10.0);
 
             return STR."\{min}/\{avg}/\{max}";
+        }
+    }
+
+    final static class FileStreamers {
+        public static FileStreamer getStreamer(FileChunk chunk) {
+            if (FORCE_PREREAD) {
+                return new ChunkPrereader(chunk);
+            }
+            if (FORCE_MAPPED) {
+                return new ChunkMapped(chunk);
+            }
+            String os = System.getProperty("os.name").toLowerCase();
+            if (os.contains("mac") || os.contains("darwin")) {
+                return new ChunkPrereader(chunk);
+            }
+            else {
+                return new ChunkMapped(chunk);
+            }
         }
     }
 
@@ -163,17 +405,29 @@ public class CalculateAverage_ricardopieper {
     }
 
     public static void main(String[] args) throws IOException, InterruptedException {
-        var debugMode = false;
+
+        var debugMode = System.getenv("DEBUG") != null && System.getenv("DEBUG").equals("true");
+        var timeIt = System.getenv("TIME") != null && System.getenv("TIME").equals("true");
+
+        Instant start = null, end = null;
+
+        if (timeIt) {
+            start = Instant.now();
+        }
+
         var path = Paths.get(FILE);
 
         var averageSizePerChunk = 16 * 1024 * 1024;
         var fileSize = Files.size(path);
         var numChunks = Math.max(1, fileSize / averageSizePerChunk);
         var chunks = splitFile(path, (int) numChunks);
-        TreeMap<String, StationMeasurements> result = null;
+        HashMap<OwnedByteSlice, StationMeasurements> result = null;
         if (debugMode) {
             for (var chunk : chunks) {
-                result = processFileChunk(chunk).asTreeMap();
+
+                var r = processFileChunk(chunk);
+                r.printCompactBucketStatistics();
+                result = r.asMap();
                 System.out.println("Processed chunk " + chunk.start);
             }
         }
@@ -182,13 +436,14 @@ public class CalculateAverage_ricardopieper {
                     .map(chunk -> {
                         try {
                             return processFileChunk(chunk);
+
                         }
                         catch (IOException e) {
                             throw new RuntimeException(e);
                         }
                     })
                     // .peek(x -> x.printStats())
-                    .map(MeasureMap::asTreeMap)
+                    .map(MeasureMap::asMap)
                     .reduce((map1, map2) -> {
                         for (var kv : map1.entrySet()) {
                             var mergedEntry = map2.get(kv.getKey());
@@ -206,7 +461,23 @@ public class CalculateAverage_ricardopieper {
                     }).get();
         }
 
-        System.out.println(result);
+        // now that we have the aggregated result, let's build a treemap with the string
+        // so that we can have a sorted map alphabetically and easily printable
+        TreeMap<String, StationMeasurements> finalResult = new TreeMap<>();
+
+        assert result != null;
+        for (var entry : result.entrySet()) {
+            finalResult.put(entry.getKey().toString(), entry.getValue());
+        }
+
+        if (timeIt) {
+            end = Instant.now();
+        }
+        System.out.println(finalResult);
+        if (timeIt) {
+            System.out.println(Duration.between(start, end));
+        }
+
     }
 
     private static final int findFirstOccurrence(long bytes, long pattern) {
@@ -275,16 +546,11 @@ public class CalculateAverage_ricardopieper {
         int nameStart = 0, nameEnd = 0;
         int tempStart = 0, tempEnd = 0;
 
-        // this +8 helps to remove a conditional check when calling getLong when there's less than 8 bytes remaining
-        ByteBuffer byteBuffer = ByteBuffer.allocate(chunk.size + 8);
-        try (var channel = new RandomAccessFile(chunk.path.toString(), "r")) {
-            channel.seek(chunk.start);
-            channel.read(byteBuffer.array(), 0, chunk.size);
-        }
-        byteBuffer.position(0);
-        while (byteBuffer.hasRemaining()) {
+        var streamer = FileStreamers.getStreamer(chunk);
 
-            long nameVector = byteBuffer.getLong();
+        while (streamer.hasRemaining()) {
+
+            long nameVector = streamer.getLong();
 
             int idx = findFirstOccurrence(nameVector, separatorMask);
 
@@ -298,8 +564,8 @@ public class CalculateAverage_ricardopieper {
                 continue;
             }
 
-            byteBuffer.position(tempStart);
-            var tempVector = byteBuffer.getLong();
+            streamer.position(tempStart);
+            var tempVector = streamer.getLong();
 
             // looking for temperature
             // this one is guaranteed to run in one go because
@@ -312,7 +578,9 @@ public class CalculateAverage_ricardopieper {
             // var tempStr = new String(tempBytes, 0, tempEnd - tempStart);
             var temp = longBytesToInt(tempVector, tempEnd - tempStart);// Float.parseFloat(tempStr);
 
-            var measurements = map.getOrAdd(byteBuffer.array(), nameVector, nameStart, nameEnd - nameStart);
+            var nameSlice = streamer.getSlice(nameStart, nameEnd - nameStart);
+
+            var measurements = map.getOrAdd(nameSlice, nameVector);
 
             measurements.min = Math.min(measurements.min, temp);
             measurements.max = Math.max(measurements.max, temp);
@@ -323,7 +591,7 @@ public class CalculateAverage_ricardopieper {
 
             nameStart = tempEnd + 1;
             nameEnd = nameStart;
-            byteBuffer.position(nameStart);
+            streamer.position(nameStart);
         }
 
         return map;
@@ -335,67 +603,23 @@ public class CalculateAverage_ricardopieper {
     // to actually copy the underlying buffer, but the profiler showed it allocated
     // way too much memory. Performance was kind of the same though...
     public static class MeasureMap {
-        public record Entry(byte[] bytes, long nameVector, StationMeasurements measurements) {
-        }
-
-        // Useful for debugging
-        public static byte[] longToBytes(long vector) {
-            byte b0 = (byte) (vector >> 64 - 8),
-                    b1 = (byte) (vector >> 64 - 16),
-                    b2 = (byte) (vector >> 64 - 24),
-                    b3 = (byte) (vector >> 64 - 32),
-                    b4 = (byte) (vector >> 64 - 40),
-                    b5 = (byte) (vector >> 64 - 48),
-                    b6 = (byte) (vector >> 64 - 56),
-                    b7 = (byte) (vector);
-
-            return new byte[]{
-                    b0, b1, b2, b3, b4, b5, b6, b7
-            };
+        public record Entry(OwnedByteSlice nameBytes, long nameVector, StationMeasurements measurements) {
+            @Override public String toString() {
+                return STR."\{nameBytes.toString()} -> \{measurements.toString()}";
+            }
         }
 
         ArrayList<Entry>[] buckets;
 
         public MeasureMap() {
             buckets = new ArrayList[32 * 1024];
-            for (int i = 0; i < 32 * 1024; i++) {
-                var bucket = new ArrayList<Entry>();
-                buckets[i] = bucket;
-            }
         }
 
-        // I tried using a vectorized hashCode using ByteVector,
-        // but I think this gets vectorized anyway because the performance is
-        // either better or the same.
-        public static int hashCode(byte[] array, int offset, int length) {
-            int result = 1;
-            for (int i = offset; i < offset + length; i++) {
-                result = 31 * result + array[i];
-            }
-            return result;
-        }
+        public StationMeasurements getOrAdd(ByteSlice byteSlice, long nameVector) {
+            long shift = (64 - (byteSlice.length * 8L));
+            nameVector = nameVector >> shift << shift;
 
-        public boolean equals(byte[] a1, int a1offset, int a1len, byte[] a2) {
-            if (a1len != a2.length) {
-                return false;
-            }
-            // I tried all sorts of trickery here,
-            // like comparing first and last before the loop.
-            // It's useless. Maybe slower. Because when strings are the same length
-            // it's a pretty high chance they are the same...
-            for (int i = 0; i < a1len; i++) {
-                if (a1[a1offset + i] != a2[i]) {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        public StationMeasurements getOrAdd(byte[] bytes, long nameVector, int offset, int length) {
-            long shift = (64 - (length * 8L));
-            long actualNameVector = nameVector >> shift << shift;
-
-            var hash = hashCode(bytes, offset, length);
+            var hash = byteSlice.hashCode();
 
             // This is a modulo operation because:
             // buckets.length is a power of 2 (like 01000000, only 1 bit is set)
@@ -405,21 +629,27 @@ public class CalculateAverage_ricardopieper {
             int bucketIndex = (buckets.length - 1) & hash;
 
             var bucket = buckets[bucketIndex];
+            if (bucket == null) {
+                buckets[bucketIndex] = new ArrayList<>();
+                bucket = buckets[bucketIndex];
+            }
             for (int i = 0; i < bucket.size(); i++) {
-
                 var item = bucket.get(i);
-                // <= 7 means we found the name and separator in one read so it's
+                // <= 7 means we found the name and separator in one read, so it's
                 // guaranteed the actualNameVector holds all the data
-                boolean found = length <= 7 ? (actualNameVector == item.nameVector) : equals(bytes, offset, length, item.bytes);
-
-                if (found) {
+                if (byteSlice.length <= 7 && item.nameBytes.bytes.length == byteSlice.length && nameVector == item.nameVector) {
                     return item.measurements;
                 }
 
+                boolean found = byteSlice.equalTo(item.nameBytes.bytes);
+                if (found) {
+                    return item.measurements;
+                }
             }
 
             // new item, consolidate
-            var newItemKey = Arrays.copyOfRange(bytes, offset, offset + length);
+            var newItemKey = byteSlice.copyBytes();
+
             var measurements = new StationMeasurements(
                     Integer.MAX_VALUE,
                     Integer.MIN_VALUE,
@@ -427,21 +657,70 @@ public class CalculateAverage_ricardopieper {
                     0);
 
             bucket.add(new Entry(
-                    newItemKey, actualNameVector, measurements));
+                    newItemKey, nameVector, measurements));
+
             return measurements;
         }
 
         // Convenience method to merge maps later
-        public TreeMap<String, StationMeasurements> asTreeMap() {
-            var result = new TreeMap<String, StationMeasurements>();
-            for (var bucket : this.buckets) {
-                for (var item : bucket) {
-                    var str = new String(item.bytes);
-                    result.put(str, item.measurements);
+        public HashMap<OwnedByteSlice, StationMeasurements> asMap() {
+            var result = new HashMap<OwnedByteSlice, StationMeasurements>();
+            for (int i = 0; i < this.buckets.length; i++) {
+                var bucket = this.buckets[i];
+                if (bucket == null)
+                    continue;
+                for (int j = 0; j < bucket.size(); j++) {
+                    var item = bucket.get(j);
+                    result.put(item.nameBytes, item.measurements);
                 }
             }
             return result;
         }
 
+        public void printCompactBucketStatistics() {
+            // Thanks ChatGPT! https://chat.openai.com/share/a8e4906b-a9b4-402e-9212-4bc468606f21
+            int[] count = new int[6]; // For 0, 1, 2, 4, 8, 16 entries
+            int over32 = 0;
+
+            for (ArrayList<Entry> bucket : buckets) {
+                if (bucket == null)
+                    continue;
+                int size = bucket.size();
+                if (size >= 32)
+                    over32++;
+                else if (size >= 16)
+                    count[5]++;
+                else if (size >= 8)
+                    count[4]++;
+                else if (size >= 4)
+                    count[3]++;
+                else if (size >= 2)
+                    count[2]++;
+                else if (size == 1)
+                    count[1]++;
+                else
+                    count[0]++;
+            }
+
+            System.out.println("Bucket Count Stats: ==0:" + count[0] + " >=1:" + count[1] + " >=2:" + count[2] +
+                    " >=4:" + count[3] + " >=8:" + count[4] + " >=16:" + count[5] + " >=32:" + over32);
+        }
+
+    }
+
+    // Useful for debugging
+    public static byte[] longToBytes(long vector) {
+        byte b0 = (byte) (vector >> 64 - 8),
+                b1 = (byte) (vector >> 64 - 16),
+                b2 = (byte) (vector >> 64 - 24),
+                b3 = (byte) (vector >> 64 - 32),
+                b4 = (byte) (vector >> 64 - 40),
+                b5 = (byte) (vector >> 64 - 48),
+                b6 = (byte) (vector >> 64 - 56),
+                b7 = (byte) (vector);
+
+        return new byte[]{
+                b0, b1, b2, b3, b4, b5, b6, b7
+        };
     }
 }


### PR DESCRIPTION
#### Check List:
- [X] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [X] All formatting changes by the build are committed
- [X] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [X] Output matches that of `calculate_average_baseline.sh`
* Execution time: 9s
* Execution time of previous implementation: 11.2s

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 30 seconds or less.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->

I determined that Linux is a bit faster with mmap reads than my mabook. On my Windows PC it's significantly faster. I still want it to run fast on my mac, so I developed a mechanism to switch file readers based on the OS. I don't know if my macbook has something misconfigured or not because this is not universal. In fact Roy Van Rijn's macbook does extremely fast mmap reads.

Also, as I suspected the final merge was taking a whole second too much. More like 2 seconds...