### PR TITLE
Bug: Update class name in calculate_average_baseline.sh

### DIFF
--- a/calculate_average_baseline.sh
+++ b/calculate_average_baseline.sh
@@ -16,4 +16,4 @@
 #
 
 JAVA_OPTS=""
-java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage
+java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_baseline


### PR DESCRIPTION
The baseline implementation has been renamed to `CalculateAverage_baseline`