### PR TITLE
CalculateAverage_ivanklaric

### DIFF
--- a/calculate_average_ivanklaric.sh
+++ b/calculate_average_ivanklaric.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+JAVA_OPTS=""
+java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ivanklaric

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ivanklaric.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ivanklaric.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright 2023 The original authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package dev.morling.onebrc;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentMap;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+public class CalculateAverage_ivanklaric {
+    private static final String FILE = "measurements.txt";
+
+    record CityTemps (double min, double max, double sum, long count) {
+        public String toString() {
+            return round(min) + "/" + round(sum / count) + "/" + round(max);
+        }
+
+        private double round(double num) {
+            return Math.round(num * 10.0) / 10.0;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        Stream<String> lines = Files.lines(Paths.get(FILE));
+        ConcurrentMap<String, CityTemps> cityStats = new ConcurrentSkipListMap<>();
+
+        lines.parallel().forEach(line -> {
+            int splitterLoc = line.indexOf(';');
+            double temp = Double.parseDouble(line.substring(splitterLoc + 1, line.length()));
+
+            cityStats.merge(line.substring(0, splitterLoc), new CityTemps(temp, temp, temp, 1),
+                    (oldValue, defaultValue) -> {
+                        return new CityTemps(Math.min(oldValue.min, temp), Math.max(oldValue.max, temp), oldValue.sum + temp, oldValue.count + 1);
+                    });
+        });
+        System.out.println(cityStats);
+    }
+}


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_ivanklaric.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time:  01:11
* Execution time of reference implementation: 02:45

I haven't coded in Java since 1.6 days, so I learned a ton about Stream API by shamelessly being inspired by CalculateAverage_abfmblr.java. Tweaked it a bit to get minor (arguably within measurement error) improvements by not using String.split(), Might go one step further to see if parseDouble() can be replaced with something faster, but I think this is a decent first attempt :)  

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
