### PR TITLE
10k improvement

### DIFF
--- a/calculate_average_mtopolnik.sh
+++ b/calculate_average_mtopolnik.sh
@@ -15,7 +15,5 @@
 #  limitations under the License.
 #
 
-# -XX:+UnlockDiagnosticVMOptions -XX:PrintAssemblyOptions=intel -XX:CompileCommand=print,*.CalculateAverage_mtopolnik::recordMeasurementAndAdvanceCursor"
-# -XX:InlineSmallCode=10000 -XX:-TieredCompilation -XX:CICompilerCount=2 -XX:CompileThreshold=1000\
 java --enable-preview \
   --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_mtopolnik

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_mtopolnik.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_mtopolnik.java
@@ -235,45 +235,40 @@ public class CalculateAverage_mtopolnik {
             return (int) ((absValue ^ signed) - signed);
         }
 
-        private int parseTemperatureSimpleAndAdvanceCursor(long startOffset) {
+        private int parseTemperatureSimpleAndAdvanceCursor(long tempStartAddress) {
             final byte minus = (byte) '-';
             final byte zero = (byte) '0';
             final byte dot = (byte) '.';
 
-            // Temperature plus the following newline is at least 4 chars, so this is always safe:
-            int fourCh = UNSAFE.getInt(inputBase + startOffset);
-            final int mask = 0xFF;
-            byte ch = (byte) (fourCh & mask);
-            int shift = 0;
+            byte ch = UNSAFE.getByte(tempStartAddress);
+            long address = tempStartAddress;
             int temperature;
             int sign;
             if (ch == minus) {
                 sign = -1;
-                shift += 8;
-                ch = (byte) ((fourCh & (mask << shift)) >>> shift);
+                address++;
+                ch = UNSAFE.getByte(address);
             }
             else {
                 sign = 1;
             }
             temperature = ch - zero;
-            shift += 8;
-            ch = (byte) ((fourCh & (mask << shift)) >>> shift);
+            address++;
+            ch = UNSAFE.getByte(address);
             if (ch == dot) {
-                shift += 8;
-                ch = (byte) ((fourCh & (mask << shift)) >>> shift);
+                address++;
+                ch = UNSAFE.getByte(address);
             }
             else {
                 temperature = 10 * temperature + (ch - zero);
-                shift += 16;
-                // The last character may be past the four loaded bytes, load it from memory.
-                // Checking that with another `if` is self-defeating for performance.
-                ch = UNSAFE.getByte(inputBase + startOffset + (shift / 8));
+                address += 2;
+                ch = UNSAFE.getByte(address);
             }
             temperature = 10 * temperature + (ch - zero);
-            // `shift` holds the number of bits in the temperature field.
+            // address - inputBase is the length of the temperature field.
             // A newline character follows the temperature, and so we advance
             // the cursor past the newline to the start of the next line.
-            cursor = startOffset + (shift / 8) + 2;
+            cursor = (address + 2) - inputBase;
             return sign * temperature;
         }
 


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
* Execution time: 3.0
* Execution time of reference implementation: 177

I think the only relevant change is in `nameEquals()`, which now uses `long` loads most of the time.

I delayed submitting this PR since I don't expect much effect on the official dataset, but the 10k dataset should see an improvement. My Hetzner instance suddenly got 2x faster so I'm a bit lost in the effect of this :D