### PR TITLE
Add elh's Go solution

### DIFF
--- a/calculate_average_elh.sh
+++ b/calculate_average_elh.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+target/elh/1brc-go

--- a/github_users.txt
+++ b/github_users.txt
@@ -54,3 +54,4 @@ jincongho;Jin Cong Ho
 yonatang;Yonatan Graber
 adriacabeza;Adrià Cabeza
 AlexanderYastrebov;Alexander Yastrebov
+elh;Eugene Huang

--- a/prepare_elh.sh
+++ b/prepare_elh.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+DOCKER_BUILDKIT=1 docker build -o target/elh src/main/go/elh

--- a/src/main/go/elh/Dockerfile
+++ b/src/main/go/elh/Dockerfile
@@ -1,0 +1,24 @@
+#
+#  Copyright 2023 The original authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+FROM golang AS builder
+WORKDIR /app
+COPY . ./
+RUN go build -ldflags "-w -s" -o /1brc-go .
+
+FROM scratch AS runner
+WORKDIR /
+COPY --from=builder /1brc-go /

--- a/src/main/go/elh/go.mod
+++ b/src/main/go/elh/go.mod
@@ -1,0 +1,3 @@
+module github.com/elh/1brc-go
+
+go 1.21.5

--- a/src/main/go/elh/main.go
+++ b/src/main/go/elh/main.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+// elh's 1BRC solution in Go
+// See https://github.com/elh/1brc-go for README and development context.
+//
+// go run main.go [measurements_file]
+
+var (
+	// Optional env vars
+	shouldProfile = os.Getenv("PROFILE") == "true"
+
+	defaultMeasurementsPath = "measurements.txt"
+	// others: "heap", "threadcreate", "block", "mutex"
+	profileTypes = []string{"goroutine", "allocs"}
+)
+
+const (
+	maxNameLen = 100
+	maxNameNum = 10000
+
+	// Tune these for performance
+	minNumParsers  = 12 // currently configured to the number of runtime.NumCPU()
+	parseChunkSize = 256 * 1024 * 1024
+)
+
+type Stats struct {
+	Min, Max, Sum float64
+	Count         int
+}
+
+// rounding floats to 1 decimal place with 0.05 rounding up to 0.1
+func round(x float64) float64 {
+	return math.Floor((x+0.05)*10) / 10
+}
+
+// parseFloatFast is a high performance float parser using the assumption that
+// the byte slice will always have a single decimal digit.
+func parseFloatFast(bs []byte) float64 {
+	var intStartIdx int // is negative?
+	if bs[0] == '-' {
+		intStartIdx = 1
+	}
+
+	v := float64(bs[len(bs)-1]-'0') / 10 // single decimal digit
+	place := 1.0
+	for i := len(bs) - 3; i >= intStartIdx; i-- { // integer part
+		v += float64(bs[i]-'0') * place
+		place *= 10
+	}
+
+	if intStartIdx == 1 {
+		v *= -1
+	}
+	return v
+}
+
+// size is the intended number of bytes to parse. buffer should be longer than size
+// because we need to continue reading until the end of the line in order to
+// properly segment the entire file and not miss any data.
+func parseAt(f *os.File, buf []byte, offset int64, size int) map[string]*Stats {
+	stats := make(map[string]*Stats, maxNameNum)
+	n, err := f.ReadAt(buf, offset) // load the buffer
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+
+	lastName := make([]byte, maxNameLen) // last name parsed
+	var lastNameLen int
+	isScanningName := true // currently scanning name or value?
+
+	// if offset is non-zero, skip to the first new line
+	var idx, start int
+	if offset != 0 {
+		for idx < n {
+			if buf[idx] == '\n' {
+				idx++
+				start = idx
+				break
+			}
+			idx++
+		}
+	}
+	// tick tock between parsing names and values while accummulating stats
+	for {
+		if isScanningName {
+			for idx < n {
+				if buf[idx] == ';' {
+					nameBs := buf[start:idx]
+					lastNameLen = copy(lastName, nameBs)
+
+					idx++
+					start = idx
+					isScanningName = false
+					break
+				}
+				idx++
+			}
+		} else {
+			for idx < n {
+				if buf[idx] == '\n' {
+					valueBs := buf[start:idx]
+					value := parseFloatFast(valueBs)
+
+					nameUnsafe := unsafe.String(&lastName[0], lastNameLen)
+					if s, ok := stats[nameUnsafe]; !ok {
+						name := string(lastName[:lastNameLen]) // actually allocate string
+						stats[name] = &Stats{Min: value, Max: value, Sum: value, Count: 1}
+					} else {
+						if value < s.Min {
+							s.Min = value
+						}
+						if value > s.Max {
+							s.Max = value
+						}
+						s.Sum += value
+						s.Count++
+					}
+
+					idx++
+					start = idx
+					isScanningName = true
+					break
+				}
+				idx++
+			}
+		}
+		// terminate when we hit the first newline after the intended size OR
+		// when we hit the end of the file
+		if (isScanningName && idx >= size) || idx >= n {
+			break
+		}
+	}
+
+	return stats
+}
+
+func printResults(stats map[string]*Stats) { // doesn't help
+	// sorted alphabetically for output
+	names := make([]string, 0, len(stats))
+	for name := range stats {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var builder strings.Builder
+	for i, name := range names {
+		s := stats[name]
+		// gotcha: first round the sum to to remove float precision errors!
+		avg := round(round(s.Sum) / float64(s.Count))
+		builder.WriteString(fmt.Sprintf("%s=%.1f/%.1f/%.1f", name, s.Min, avg, s.Max))
+		if i < len(names)-1 {
+			builder.WriteString(", ")
+		}
+	}
+
+	writer := bufio.NewWriter(os.Stdout)
+	fmt.Fprintf(writer, "{%s}\n", builder.String())
+	writer.Flush()
+}
+
+// Read file in chunks and parse concurrently. N parsers work off of a chunk
+// offset chan and send results on an output chan. The results are merged into a
+// single map of stats and printed.
+func main() {
+	measurementsPath := defaultMeasurementsPath
+	if len(os.Args) > 1 {
+		measurementsPath = os.Args[1]
+	}
+
+	if shouldProfile {
+		nowUnix := time.Now().Unix()
+		os.MkdirAll(fmt.Sprintf("profiles/%d", nowUnix), 0755)
+		for _, profileType := range profileTypes {
+			file, _ := os.Create(fmt.Sprintf("profiles/%d/%s.%s.pprof",
+				nowUnix, filepath.Base(measurementsPath), profileType))
+			defer file.Close()
+			defer pprof.Lookup(profileType).WriteTo(file, 0)
+		}
+
+		file, _ := os.Create(fmt.Sprintf("profiles/%d/%s.cpu.pprof",
+			nowUnix, filepath.Base(measurementsPath)))
+		defer file.Close()
+		pprof.StartCPUProfile(file)
+		defer pprof.StopCPUProfile()
+	}
+
+	// read file
+	f, err := os.Open(measurementsPath)
+	if err != nil {
+		log.Fatal(fmt.Errorf("failed to open %s file: %w", measurementsPath, err))
+	}
+	defer f.Close()
+
+	info, err := f.Stat()
+	if err != nil {
+		log.Fatal(fmt.Errorf("failed to read %s file: %w", measurementsPath, err))
+	}
+
+	// kick off "parser" workers
+	numParsers := runtime.NumCPU()
+	if minNumParsers > numParsers {
+		numParsers = minNumParsers
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(numParsers)
+
+	// buffered to not block on merging
+	chunkOffsetCh := make(chan int64, numParsers)
+	chunkStatsCh := make(chan map[string]*Stats, numParsers)
+
+	go func() {
+		for i := 0; i < int(info.Size()); i++ {
+			chunkOffsetCh <- int64(i)
+			i += parseChunkSize
+		}
+		close(chunkOffsetCh)
+	}()
+
+	for i := 0; i < numParsers; i++ {
+		// WARN: w/ extra padding for line overflow. Each chunk should be read past
+		// the intended size to the next new line. 128 bytes should be enough for
+		// a max 100 byte name + the float value.
+		buf := make([]byte, parseChunkSize+128)
+		go func() {
+			for chunkOffset := range chunkOffsetCh {
+				chunkStatsCh <- parseAt(f, buf, chunkOffset, parseChunkSize)
+			}
+			wg.Done()
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(chunkStatsCh)
+	}()
+
+	mergedStats := make(map[string]*Stats, maxNameNum)
+	for chunkStats := range chunkStatsCh {
+		for name, s := range chunkStats {
+			if ms, ok := mergedStats[name]; !ok {
+				mergedStats[name] = s
+			} else {
+				if s.Min < ms.Min {
+					ms.Min = s.Min
+				}
+				if s.Max > ms.Max {
+					ms.Max = s.Max
+				}
+				ms.Sum += s.Sum
+				ms.Count += s.Count
+			}
+		}
+	}
+
+	printResults(mergedStats)
+}


### PR DESCRIPTION
My approach was focused on optimizing the file reading by aggressively minimizing memory allocations. I had the most fun optimizing this flow and then just added concurrency at the end. The only interesting bits are a simple custom `parseFloatFast` function and using `unsafe.String` in read-only use cases to avoid allocation of strings.

I think it might be competitive. There is a pretty funny lesson to be learned here that everyone's solution is the fastest on their own machine 😄
<br>

### 1/18 Timing Update
Improved on my machine to 5.5s after adjusting buffer sizes using hyperfine testing. Tuned for 2023 Macbook M2 Pro
```
Benchmark 1: ./bin/1brc-go 2>&1
  Time (mean ± σ):      5.479 s ±  0.144 s    [User: 38.371 s, System: 1.801 s]
  Range (min … max):    5.376 s …  5.733 s    5 runs
```

### Original Timing
Top Java and Go solutions measured on a 2023 Apple M2 Pro Macbook with 10 cores and 16GB RAM.
| # | Result (m:s.ms) | Implementation     | JDK | Submitter     | Notes     |
|---|-----------------|--------------------|-----|---------------|-----------|
| 1 | 00:06.876 | [link](https://github.com/elh/1brc-go)| 🔷 Go 1.21.5 | [Eugene Huang](https://github.com/elh) | Mine! 👈 |
| 2 | 00:07.602 | [link](https://gist.github.com/corlinp/176a97c58099bca36bcd5679e68f9708)| 🔷 Go 1.21.5 | [Corlin Palmer](https://github.com/corlinp) | Go implementation |
| 3 | 00:13.765 | [link](https://github.com/gunnarmorling/1brc/blob/main/src/main/java/dev/morling/onebrc/CalculateAverage_royvanrijn.java)| 21.0.1-graal | [Roy van Rijn](https://github.com/royvanrijn) | GraalVM native binary |
|   | 00:13.989 | [link](https://github.com/gunnarmorling/1brc/blob/main/src/main/java/dev/morling/onebrc/CalculateAverage_artsiomkorzun.java)| 21.0.1-graal | [Artsiom Korzun](https://github.com/artsiomkorzun) |  |
|   | 00:14.044 | [link](https://github.com/gunnarmorling/1brc/blob/main/src/main/java/dev/morling/onebrc/CalculateAverage_thomaswue.java)| 21.0.1-graal | [Thomas Wuerthinger](https://github.com/thomaswue) | GraalVM native binary |
|   | 00:14.464 | [link](https://github.com/AlexanderYastrebov/1brc/tree/go-implementation/src/main/go)| 🔷 Go 1.21.5 | [Alexander Yastrebov](https://github.com/AlexanderYastrebov) | Go implementation |
|   | 00:14.839 | [link](https://github.com/gunnarmorling/1brc/blob/main/src/main/java/dev/morling/onebrc/CalculateAverage_mtopolnik.java)| 21.0.1-graal | [Marko Topolnik](https://github.com/mtopolnik) |  |
|   | 00:14.949 | [link](https://github.com/gunnarmorling/1brc/blob/main/src/main/java/dev/morling/onebrc/CalculateAverage_merykittyunsafe.java)| 21.0.1-open | [merykittyunsafe](https://github.com/merykittyunsafe) |  |
|   | 00:16.075 | [link](https://github.com/jkroepke/1brc-go/tree/main/go)| 🔷 Go 1.21.5 | [Jan-Otto Kröpke](https://github.com/jkroepke) | Go implementation |

<sub>_* Measured w/ Docker Desktop turned off which was a drag with its 1GB RAM VM._</sub>
<sub>_* Table and final benchmark were generated with different measurements_1B.txt files. Table was run on a measurements_1B.txt file generated around a week ago._</sub>

<br>

Shoutout to @AlexanderYastrebov who's push on supporting language-agnostic solutions motivated me to work on mine. And shoutout to @gunnarmorling. Excited to share with coworkers :)

<br>
<br>

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number) -- no custom hash used

* Execution time: ~7.10s~ 5.48s
* Execution time of reference implementation: 167.08s

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
