### PR TITLE
Fix masking

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_artsiomkorzun.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_artsiomkorzun.java
@@ -431,7 +431,8 @@ public class CalculateAverage_artsiomkorzun {
         }
 
         private static long mask(long word, long separator) {
-            return word & ((separator >>> 7) - 1) & 0x00FFFFFFFFFFFFFFL;
+            long mask = ((separator - 1) ^ separator) >>> 8;
+            return word & mask;
         }
 
         private static int length(long separator) {


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: same
* Execution time of reference implementation: a lot

One line change, but wasted 2 hours. 

@gunnarmorling should work with this fix.