### PR TITLE
test.sh: prepare_<username>.sh should be sourced

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -15,8 +15,6 @@
 #  limitations under the License.
 #
 
-set -euo pipefail
-
 DEFAULT_INPUT="src/test/resources/samples/*.txt"
 FORK=${1:-""}
 INPUT=${2:-$DEFAULT_INPUT}
@@ -36,8 +34,10 @@ if [ "$#" -eq 0 ] || [ "$#" -gt 2 ] || [ "$FORK" = "-h" ]; then
 fi
 
 if [ -f "./prepare_$FORK.sh" ]; then
-  "./prepare_$FORK.sh"
+  source "./prepare_$FORK.sh"
 fi
+
+set -euo pipefail
 
 for sample in $(ls $INPUT); do
   echo "Validating calculate_average_$FORK.sh -- $sample"


### PR DESCRIPTION
I don't know whether invoking user's `prepare_<username>.sh` script from the `test.sh` script was meant just to test that the prepare script runs without problems or to actually prepare the user's environment for later running the calculate script. If it was the later, then prepare script should be sourced instead of executed as a sub-process. Only in that case will environment be set for the process (and sub-processes) that are executing the calculate script.

Am I right?