### PR TITLE
Try out every tuning under the sun

### DIFF
--- a/calculate_average_iziamos.sh
+++ b/calculate_average_iziamos.sh
@@ -15,5 +15,11 @@
 #  limitations under the License.
 #
 
-JAVA_OPTS="--enable-preview --add-modules=jdk.incubator.vector -Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0 -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms16m -Xmx16m -XX:-AlwaysPreTouch -XX:-TieredCompilation -XX:CICompilerCount=1"
+JAVA_OPTS="--enable-preview
+  -XX:+UnlockExperimentalVMOptions \
+  -XX:+UseEpsilonGC -Xms16m -Xmx16m -XX:-AlwaysPreTouch \
+  -XX:-TieredCompilation -XX:CICompilerCount=1 -XX:CompilationMode=high-only \
+  -XX:C1MaxTrivialSize=500 -XX:-UseCountedLoopSafepoints -XX:+UseCMoveUnconditionally -XX:+DisableAttachMechanism \
+  -XX:-PreserveFramePointer -Xnoclassgc -disablesystemassertions -XX:-UsePerfData  \
+  -XX:-UseTransparentHugePages -XX:-UseCompressedOops"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_iziamos


### PR DESCRIPTION
Hi there, I had some spare time to look at this. It doesn't really constitute a huge code change on my behalf but it may be interesting for you to run as well as it may be the submission with the most flags at this point. Obviously most of these may be silly and won't hold up on the test rig or I hallucinated the improvements.

* I've changed the map size, it helped because I suspect there are fewer hash collisions now.
* I used the number parsing code from the top submission which helped somewhat. There was no point trying to write that myself as it seems to be a solved problem now.
* I've added every tuning flag that seemed to affect execution time on my computer.

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: ranges between 1-1.1 sec on my system.
* Execution time of reference implementation: 47 sec.

I'd predict under 5 seconds for this one given the new parsing code but it would be interesting to see how far the tuning gets it.

Also if it's not too much of an ask I think it would be interesting to see how long the JVM with --dry-run enabled takes on the test rig. I see:

real	        0m0.019s
user	0m0.012s
sys	        0m0.011s

locally. Does this mean the jvm takes that long to load or does it just exit after parsing the arguments? One would have to take a look but  simple hello world does it in iirc 300 millis on my system.

Would be cool if you could get those numbers, totally understand if you are swamped by this whole thing though.

Thanks
