### PR TITLE
jerrinot's hashcode fix and perf. improvements

### DIFF
--- a/calculate_average_jerrinot.sh
+++ b/calculate_average_jerrinot.sh
@@ -17,5 +17,5 @@
 
 # -XX:+UnlockDiagnosticVMOptions -XX:PrintAssemblyOptions=intel -XX:CompileCommand=print,*.CalculateAverage_mtopolnik::recordMeasurementAndAdvanceCursor"
 # -XX:InlineSmallCode=10000 -XX:-TieredCompilation -XX:CICompilerCount=2 -XX:CompileThreshold=1000\
-java --enable-preview \
+java -XX:+UseParallelGC  --enable-preview \
   --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_jerrinot


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [ ] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: 3.7s
* Execution time of reference implementation: looong

10k is no longer timing out. It's still dog-slow tho. 
Performance on the original test set improved a bit. Hopefully enough to jump over @mtopolnik  :-D