### PR TITLE
Map.combine() to Map.merge() and Map[Integer, Text] to IntObjectHashMap[Text]

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_japplis.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_japplis.java
@@ -448,6 +448,10 @@ public class CalculateAverage_japplis {
             for (IntEntry entry : this.entries) {
                 if (entry != null) {
                     entrySet.add(entry);
+                    while (entry.next != null) {
+                        entry = entry.next;
+                        entrySet.add(entry);
+                    }
                 }
             }
             return entrySet;


### PR DESCRIPTION
- Changed Map.combine() to Map.merge() and Map.forEach() to 'for each' loop
- Replaced Map[Integer, Text] to IntObjectHashMap[Text]
- Some readability improvements

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
Ran the tests 10 times.
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)
-> Line 360 for the text pool
-> Line 468 and 486 for the IntObjectHashMap

* Execution time: 5" laptop
* Execution time of reference implementation: 2'20"

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
