### PR TITLE
Avoiding string creation as much as possible

### DIFF
--- a/calculate_average_adriacabeza.sh
+++ b/calculate_average_adriacabeza.sh
@@ -16,6 +16,6 @@
 #
 
 
-JAVA_OPTS="-XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC"
+JAVA_OPTS="-XX:+UseStringDeduplication -XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -XX:+AlwaysPreTouch"
 java --enable-preview  -classpath target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_adriacabeza
 

--- a/github_users.txt
+++ b/github_users.txt
@@ -52,3 +52,4 @@ gnmathur;Gaurav Mathur
 vemana;Subrahmanyam
 jincongho;Jin Cong Ho
 yonatang;Yonatan Graber
+adriacabeza;Adrià Cabeza


### PR DESCRIPTION
Changes added to the first contribution:
- It avoids creating unnecessary Strings objects and handles with the station names with its - - djb2 hashes instead 
- Initializes hashmaps
- Adds -XX:+AlwaysPreTouch

Values achieved in my Macbook Apple M1 Max:

```
Benchmark 1: java --enable-preview -classpath /Users/adria.cabezasantanna/1brc/target/classes dev.morling.onebrc.CalculateAverage_adriacabeza
  Time (mean ± σ):      3.957 s ±  0.258 s    [User: 32.479 s, System: 1.186 s]
  Range (min … max):    3.574 s …  4.393 s    10 runs
```

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`