### PR TITLE
small improvements

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_YannMoisan.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_YannMoisan.java
@@ -104,10 +104,7 @@ public class CalculateAverage_YannMoisan {
                     break;
                 field[fieldCurrentIndex++] = fieldByte;
             }
-            var dst = new byte[fieldCurrentIndex];
-            System.arraycopy(field, 0, dst, 0, fieldCurrentIndex);
-            var fieldStr = new Location(dst);
-            // System.arraycopy(field, 0, dst, 0, fieldCurrentIndex);
+            var fieldStr = new Location(Arrays.copyOfRange(field, 0, fieldCurrentIndex));
             var number = 0;
             var sign = 1;
             while (bb.position() < limit) {
@@ -119,9 +116,15 @@ public class CalculateAverage_YannMoisan {
                 else if (numberByte != '.')
                     number = number * 10 + (numberByte - '0');
             }
-            stats.computeIfAbsent(fieldStr,
-                    k -> new Stat())
-                    .update(sign * number);
+            var v = stats.get(fieldStr);
+            if (v == null) {
+                var vv = new Stat();
+                vv.update(sign * number);
+                stats.put(fieldStr, vv);
+            }
+            else {
+                v.update(sign * number);
+            }
         }
 
         return stats;


### PR DESCRIPTION
- inline computeIfAbsent
- replace arraycopy by copyOfRange

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time:
* Execution time of reference implementation:

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
