### PR TITLE
use thomaswue trick, use parallelism, slightly faster

### DIFF
--- a/prepare_abeobk.sh
+++ b/prepare_abeobk.sh
@@ -16,10 +16,10 @@
 #
 
 source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk use java 21.0.1-graal 1>&2
+sdk use java 21.0.2-graal 1>&2
 
 # ./mvnw clean verify removes target/ and will re-trigger native image creation.
 if [ ! -f target/CalculateAverage_abeobk_image ]; then
-    NATIVE_IMAGE_OPTS="--gc=epsilon -O3 -march=native -R:MaxHeapSize=128m --enable-preview --initialize-at-build-time=dev.morling.onebrc.CalculateAverage_abeobk"
+    NATIVE_IMAGE_OPTS="--gc=epsilon -O3 -march=native -R:MaxHeapSize=128m -H:InlineAllBonus=10 -H:-ParseRuntimeOptions --enable-preview --initialize-at-build-time=dev.morling.onebrc.CalculateAverage_abeobk"
     native-image $NATIVE_IMAGE_OPTS -cp target/average-1.0.0-SNAPSHOT.jar -o target/CalculateAverage_abeobk_image dev.morling.onebrc.CalculateAverage_abeobk
 fi


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

Applying thomaswue trick and some minor optimization
Slightly faster than top 3 on my box

Standard data
Benchmark 1: ./calculate_average_abeobk.sh
  Time (mean ± σ):     653.4 ms ±   8.4 ms    [User: 2.2 ms, System: 5.8 ms]
  Range (min … max):   640.8 ms … 669.6 ms    10 runs

10k stations data
Benchmark 1: ./calculate_average_abeobk.sh
  Time (mean ± σ):      1.675 s ±  0.025 s    [User: 0.002 s, System: 0.006 s]
  Range (min … max):    1.637 s …  1.706 s    10 runs

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
