### PR TITLE
Simplify station dedupe

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
@@ -19,6 +19,7 @@ import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
 
+import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.nio.ByteOrder;
@@ -41,7 +42,7 @@ import static java.lang.foreign.ValueLayout.*;
  *
  * Timings on 4 core i7-7500U CPU @ 2.70GHz:
  * average_baseline: 4m48s
- * ianopolous:         14s
+ * ianopolous:         13.8s
 */
 public class CalculateAverage_ianopolousfast {
 
@@ -107,22 +108,15 @@ public class CalculateAverage_ianopolousfast {
     public static Stat dedupeStation(long start, long end, long hash, MemorySegment buffer, Stat[] stations) {
         int index = hashToIndex(hash, MAX_STATIONS);
         Stat match = stations[index];
-        if (match == null) {
-            Stat res = createStation(start, end, buffer);
-            stations[index] = res;
-            return res;
+        while (match != null) {
+            if (matchingStationBytes(start, end, buffer, match))
+                return match;
+            index = (index + 1) % stations.length;
+            match = stations[index];
         }
-        else {
-            while (match != null) {
-                if (matchingStationBytes(start, end, buffer, match))
-                    return match;
-                index = (index + 1) % stations.length;
-                match = stations[index];
-            }
-            Stat res = createStation(start, end, buffer);
-            stations[index] = res;
-            return res;
-        }
+        Stat res = createStation(start, end, buffer);
+        stations[index] = res;
+        return res;
     }
 
     static long maskHighBytes(long d, int nbytes) {


### PR DESCRIPTION
Simplify dedupe station to reduce branches.
Use sub process trick to avoid mem unmap cost.

#### Check List:
- [X] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [X] All formatting changes by the build are committed
- [X] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [X] Output matches that of `calculate_average_baseline.sh`
- [X] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: 13.8s
* Execution time of reference implementation: 288s