### PR TITLE
improve hard disk access locality, another 8%

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_abeobk.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_abeobk.java
@@ -183,7 +183,7 @@ public class CalculateAverage_abeobk {
         return (short) ((abs_val ^ signed) - signed);
     }
 
-    //Thread pool worker
+    // Thread pool worker
     static final class Worker extends Thread {
         final int thread_id;
 

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_abeobk.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_abeobk.java
@@ -183,6 +183,7 @@ public class CalculateAverage_abeobk {
         return (short) ((abs_val ^ signed) - signed);
     }
 
+    //Thread pool worker
     static final class Worker extends Thread {
         final int thread_id;
 
@@ -198,7 +199,8 @@ public class CalculateAverage_abeobk {
             int id;
             int cls = 0;
 
-            // process in small chunk to maintain disk locality
+            // process in small chunk to maintain disk locality (artsiomkorzun trick)
+            // but keep going instead of merging
             while ((id = chunk_id.getAndIncrement()) < chunk_cnt) {
                 long addr = start_addr + id * CHUNK_SZ;
                 long end = Math.min(addr + CHUNK_SZ, end_addr);


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

Last version:
Benchmark 1: ./calculate_average_abeobk.sh
Time (mean ± σ): 611.7 ms ± 10.8 ms [User: 1.6 ms, System: 6.3 ms]
Range (min … max): 597.6 ms … 638.7 ms 10 runs

This version:
Benchmark 1: ./calculate_average_abeobk.sh
  Time (mean ± σ):     561.8 ms ±   6.6 ms    [User: 2.1 ms, System: 1.7 ms]
  Range (min … max):   544.4 ms … 569.8 ms    10 runs

This runs faster on my machine, but I'm not sure if it will have the same performance on the evaluation one. This version processes data in small chunks, each 4MB in size, thereby improving hard disk access locality.

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
