### PR TITLE
Larger heap, small tweaks

### DIFF
--- a/prepare_royvanrijn.sh
+++ b/prepare_royvanrijn.sh
@@ -21,8 +21,8 @@ sdk use java 21.0.2-graal 1>&2
 # ./mvnw clean verify removes target/ and will re-trigger native image creation.
 if [ ! -f target/CalculateAverage_royvanrijn_image ]; then
 
-    JAVA_OPTS="--enable-preview -dsa"
-    NATIVE_IMAGE_OPTS="--initialize-at-build-time=dev.morling.onebrc.CalculateAverage_royvanrijn --gc=epsilon -Ob -O3 -march=native --strict-image-heap $JAVA_OPTS"
+    JAVA_OPTS="--enable-preview"
+    NATIVE_IMAGE_OPTS="-H:+UnlockExperimentalVMOptions --initialize-at-build-time=dev.morling.onebrc.CalculateAverage_royvanrijn --gc=epsilon -O3 -march=native -R:MaxHeapSize=515m -H:-GenLoopSafepoints -H:InlineAllBonus=10 -H:-ParseRuntimeOptions $JAVA_OPTS"
 
     native-image $NATIVE_IMAGE_OPTS -cp target/average-1.0.0-SNAPSHOT.jar -o target/CalculateAverage_royvanrijn_image dev.morling.onebrc.CalculateAverage_royvanrijn
 fi


### PR DESCRIPTION
More small tweaks, perf from 775~ to 738~.

Let's see if 512m is enough to run the tests, locally all (incl the big one) runs fine with 64m.

Also some slight tweaks to the code.

#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time:
* Execution time of reference implementation:

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
