### PR TITLE
Reduce preferred vector size

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
@@ -49,9 +49,9 @@ public class CalculateAverage_ianopolousfast {
     public static final int MAX_LINE_LENGTH = 107;
     public static final int MAX_STATIONS = 1 << 14;
     private static final OfLong LONG_LAYOUT = JAVA_LONG_UNALIGNED.withOrder(ByteOrder.BIG_ENDIAN);
-    private static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_PREFERRED.length() >= 32
-            ? ByteVector.SPECIES_256
-            : ByteVector.SPECIES_128;
+    private static final VectorSpecies<Byte> BYTE_SPECIES = ByteVector.SPECIES_PREFERRED.length() >= 16
+            ? ByteVector.SPECIES_128
+            : ByteVector.SPECIES_64;
 
     public static void main(String[] args) throws Exception {
         Arena arena = Arena.global();
@@ -132,7 +132,7 @@ public class CalculateAverage_ianopolousfast {
         if (keySize <= 8) {
             first8 = maskHighBytes(first8, keySize & 0x07);
         }
-        else if (keySize <= 16) {
+        else if (keySize < 16) {
             second8 = maskHighBytes(buffer.get(LONG_LAYOUT, lineStart + 8), keySize & 0x07);
         }
         else if (keySize == BYTE_SPECIES.vectorByteSize()) {
@@ -182,7 +182,7 @@ public class CalculateAverage_ianopolousfast {
         if (keySize <= 8) {
             first8 = maskHighBytes(first8, keySize & 0x07);
         }
-        else if (keySize <= 16) {
+        else if (keySize < 16) {
             second8 = maskHighBytes(buffer.get(LONG_LAYOUT, lineStart + 8), keySize & 0x07);
         }
         else if (keySize == BYTE_SPECIES.vectorByteSize()) {


### PR DESCRIPTION
This makes it ~.5s faster on my 12 core machine

#### Check List:
- [X] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [X] All formatting changes by the build are committed
- [X] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [X] Output matches that of `calculate_average_baseline.sh`
- [X] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: 4.5s
* Execution time of reference implementation: 3m25s

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
