### PR TITLE
shipilev: Amendments to version 4

### DIFF
--- a/calculate_average_shipilev.sh
+++ b/calculate_average_shipilev.sh
@@ -15,12 +15,11 @@
 #  limitations under the License.
 #
 
-JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms64m -Xmx64m -XX:+AlwaysPreTouch -XX:+UseTransparentHugePages
--XX:-TieredCompilation -XX:CICompilerCount=2 -XX:-UseCountedLoopSafepoints -XX:+TrustFinalNonStaticFields
+JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms1g -Xmx1g -XX:-AlwaysPreTouch -XX:+UseTransparentHugePages
+-XX:-TieredCompilation -XX:-UseCountedLoopSafepoints -XX:+TrustFinalNonStaticFields -XX:CompileThreshold=2048
 --add-opens java.base/java.nio=ALL-UNNAMED --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
 -XX:+UnlockDiagnosticVMOptions -XX:CompileCommand=quiet
 -XX:CompileCommand=dontinline,dev.morling.onebrc.CalculateAverage_shipilev\$ParsingTask::seqCompute
 -XX:CompileCommand=dontinline,dev.morling.onebrc.CalculateAverage_shipilev\$MeasurementsMap::updateSlow
--XX:CompileCommand=inline,dev.morling.onebrc.CalculateAverage_shipilev::nameMatches
--XX:CompileThreshold=2048"
+-XX:CompileCommand=inline,dev.morling.onebrc.CalculateAverage_shipilev::nameMatches"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_shipilev

--- a/calculate_average_shipilev.sh
+++ b/calculate_average_shipilev.sh
@@ -21,5 +21,5 @@ JAVA_OPTS="-XX:+UnlockExperimentalVMOptions -XX:+UseEpsilonGC -Xms1g -Xmx1g -XX:
 -XX:+UnlockDiagnosticVMOptions -XX:CompileCommand=quiet
 -XX:CompileCommand=dontinline,dev.morling.onebrc.CalculateAverage_shipilev\$ParsingTask::seqCompute
 -XX:CompileCommand=dontinline,dev.morling.onebrc.CalculateAverage_shipilev\$MeasurementsMap::updateSlow
--XX:CompileCommand=inline,dev.morling.onebrc.CalculateAverage_shipilev::nameMatches"
+-XX:CompileCommand=inline,dev.morling.onebrc.CalculateAverage_shipilev\$Bucket::matches"
 java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_shipilev

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_shipilev.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_shipilev.java
@@ -102,45 +102,12 @@ public class CalculateAverage_shipilev {
 
     // ========================= MEATY GRITTY PARTS: PARSE AND AGGREGATE =========================
 
-    // Little helper method to compare the array with given bytebuffer range.
-    public static boolean nameMatches(Bucket bucket, ByteBuffer cand, int begin, int end) {
-        byte[] orig = bucket.name;
-        int origLen = orig.length;
-        int candLen = end - begin;
-        if (origLen != candLen) {
-            return false;
-        }
-
-        // Check the tails first, to simplify the matches.
-        if (origLen >= 8) {
-            if (bucket.tail1 != cand.getLong(end - 8)) {
-                return false;
-            }
-            if (origLen >= 16) {
-                if (bucket.tail2 != cand.getLong(end - 16)) {
-                    return false;
-                }
-                origLen -= 16;
-            }
-            else {
-                origLen -= 8;
-            }
-        }
-
-        // Check the rest.
-        for (int i = 0; i < origLen; i++) {
-            if (orig[i] != cand.get(begin + i)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     public static final class Bucket {
-        // Raw station name, its hash, and tails.
-        public final byte[] name;
+        // Raw station name, its hash, and prefixes.
+        public final byte[] nameTail;
+        public final int len;
         public final int hash;
-        public final long tail1, tail2;
+        public final int prefix1, prefix2;
 
         // Temperature values, in 10x scale.
         public long sum;
@@ -149,22 +116,78 @@ public class CalculateAverage_shipilev {
         public int max;
 
         public Bucket(ByteBuffer slice, int begin, int end, int hash, int temp) {
-            int len = end - begin;
+            len = end - begin;
 
-            // We are checking the names on hot-path. Therefore, it is convenient
-            // to keep allocation for names near the buckets.
-            this.name = new byte[len];
-            slice.get(begin, name, 0, len);
+            // Also pick up any prefixes to simplify future matches.
+            int tailStart = 0;
+            if (len >= 8) {
+                prefix1 = slice.getInt(begin + 0);
+                prefix2 = slice.getInt(begin + 4);
+                tailStart += 8;
+            }
+            else if (len >= 4) {
+                prefix1 = slice.getInt(begin + 0);
+                prefix2 = 0;
+                tailStart += 4;
+            }
+            else {
+                prefix1 = 0;
+                prefix2 = 0;
+            }
 
-            // Also pick up any tail to simplify future matches.
-            this.tail1 = (len < 8) ? 0 : slice.getLong(end - 8);
-            this.tail2 = (len < 16) ? 0 : slice.getLong(end - 16);
+            // The rest goes to tail byte array. We are checking it names on hot-path.
+            // Therefore, it is convenient to keep allocation for names near the buckets.
+            int tailLen = len - tailStart;
+            nameTail = new byte[tailLen];
+            slice.get(begin + tailStart, nameTail, 0, tailLen);
 
             this.hash = hash;
             this.sum = temp;
             this.count = 1;
             this.min = temp;
             this.max = temp;
+        }
+
+        // Little helper method to compare the array with given bytebuffer range.
+        public boolean matches(ByteBuffer cand, int begin, int end) {
+            int origLen = len;
+            int candLen = end - begin;
+            if (origLen != candLen) {
+                return false;
+            }
+
+            // Check the prefixes first, to simplify the matches.
+            int tailStart = 0;
+            if (origLen >= 8) {
+                if (prefix1 != cand.getInt(begin)) {
+                    return false;
+                }
+                if (prefix2 != cand.getInt(begin + 4)) {
+                    return false;
+                }
+                tailStart += 8;
+            }
+            else if (origLen >= 4) {
+                if (prefix1 != cand.getInt(begin)) {
+                    return false;
+                }
+                tailStart += 4;
+            }
+
+            // Check the rest.
+            for (int i = 0; i < origLen - tailStart; i++) {
+                if (nameTail[i] != cand.get(begin + tailStart + i)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public boolean matches(Bucket other) {
+            return len == other.len &&
+                    prefix1 == other.prefix1 &&
+                    prefix2 == other.prefix2 &&
+                    Arrays.equals(nameTail, other.nameTail);
         }
 
         public void merge(int value) {
@@ -186,8 +209,19 @@ public class CalculateAverage_shipilev {
         }
 
         public Row toRow() {
+            // Reconstruct the name
+            ByteBuffer bb = ByteBuffer.allocate(len);
+            bb.order(ByteOrder.LITTLE_ENDIAN);
+            if (len >= 4) {
+                bb.putInt(prefix1);
+            }
+            if (len >= 8) {
+                bb.putInt(prefix2);
+            }
+            bb.put(nameTail);
+
             return new Row(
-                    new String(name),
+                    new String(Arrays.copyOf(bb.array(), len)),
                     Math.round((double) min) / 10.0,
                     Math.round((double) sum / count) / 10.0,
                     Math.round((double) max) / 10.0);
@@ -217,7 +251,7 @@ public class CalculateAverage_shipilev {
                     buckets[idx] = new Bucket(name, begin, end, hash, temp);
                     return;
                 }
-                else if ((cur.hash == hash) && nameMatches(cur, name, begin, end)) {
+                else if ((cur.hash == hash) && cur.matches(name, begin, end)) {
                     // Same as bucket fastpath. Check for collision by checking the full hash
                     // first (since the index is truncated by map size), and then the exact name.
                     cur.merge(temp);
@@ -242,7 +276,7 @@ public class CalculateAverage_shipilev {
                         buckets[idx] = other;
                         break;
                     }
-                    else if ((cur.hash == other.hash) && Arrays.equals(cur.name, other.name)) {
+                    else if ((cur.hash == other.hash) && cur.matches(other)) {
                         cur.merge(other);
                         break;
                     }
@@ -423,7 +457,7 @@ public class CalculateAverage_shipilev {
 
                 // Time to update!
                 Bucket bucket = buckets[nameHash & (MAP_SIZE - 1)];
-                if ((bucket != null) && (nameHash == bucket.hash) && nameMatches(bucket, slice, nameBegin, nameEnd)) {
+                if ((bucket != null) && (nameHash == bucket.hash) && bucket.matches(slice, nameBegin, nameEnd)) {
                     // Lucky fast path, existing bucket hit. Most of the time we complete here.
                     bucket.merge(temp);
                 }


### PR DESCRIPTION
#### Check List:
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] ~For new entries, or after substantial changes~ Not a new entry.

A few simple touchups after running with 8 cores:
 - Default FJP pool is one thread short when execution is capped at 8 cores;
 - No need for some JVM options in the constrained run;
 - Tiny locality improvements;

On standard dataset:

```
# Old impl:
Benchmark 1: ./calculate_average_shipilev.sh
  Time (mean ± σ):      3.819 s ±  0.091 s    [User: 25.632 s, System: 0.982 s]
  Range (min … max):    3.677 s …  3.990 s    10 runs

# New impl:
Benchmark 1: ./calculate_average_shipilev.sh
  Time (mean ± σ):      3.252 s ±  0.086 s    [User: 24.463 s, System: 0.906 s]
  Range (min … max):    3.196 s …  3.489 s    10 runs
```

So it should be about 15% faster.

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
