### PR TITLE
serkan-ozal's 5th submission:

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_serkan_ozal.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_serkan_ozal.java
@@ -59,8 +59,9 @@ public class CalculateAverage_serkan_ozal {
             ? ByteVector.SPECIES_128
             : ByteVector.SPECIES_64;
     private static final int BYTE_SPECIES_SIZE = BYTE_SPECIES.vectorByteSize();
-
+    private static final MemorySegment ALL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
     private static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
+
     private static final char NEW_LINE_SEPARATOR = '\n';
     private static final char KEY_VALUE_SEPARATOR = ';';
     private static final int MAX_LINE_LENGTH = 128;
@@ -341,7 +342,7 @@ public class CalculateAverage_serkan_ozal {
 
             // Read and process region - main
             for (regionPtr = regionStart; regionPtr < regionMainLimit;) {
-                regionPtr = doProcessLine(region, regionAddress, regionPtr, vectorSize);
+                regionPtr = doProcessLine(regionPtr, vectorSize);
             }
 
             // Read and process region - tail
@@ -358,13 +359,14 @@ public class CalculateAverage_serkan_ozal {
             }
         }
 
-        private long doProcessLine(MemorySegment region, long regionAddress, long regionPtr, int vectorSize) {
+        private long doProcessLine(long regionPtr, int vectorSize) {
             // Find key/value separator
             ////////////////////////////////////////////////////////////////////////////////////////////////////////
             long keyStartPtr = regionPtr;
 
             // Vectorized search for key/value separator
-            ByteVector keyVector = ByteVector.fromMemorySegment(BYTE_SPECIES, region, regionPtr - regionAddress, NATIVE_BYTE_ORDER);
+            ByteVector keyVector = ByteVector.fromMemorySegment(BYTE_SPECIES, ALL, regionPtr, NATIVE_BYTE_ORDER);
+
             int keyLength = keyVector.compare(VectorOperators.EQ, KEY_VALUE_SEPARATOR).firstTrue();
             // Check whether key/value separator is found in the first vector (city name is <= vector size)
             if (keyLength != vectorSize) {


### PR DESCRIPTION
- use region address directly over null base memory address to get rid of extra offset calculation

#### Check List:

- [x] You have run `./mvnw verify` and the project builds successfully
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number): `640`

* Execution time: `3.0s` (It was `3.3s` in the 4th submission in my testing env)
* Execution time of reference implementation: `5m 54.1s`

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
