### PR TITLE
batched writing to disk for randomized temperatures

### DIFF
--- a/src/main/python/create_measurements.py
+++ b/src/main/python/create_measurements.py
@@ -110,15 +110,18 @@ def build_test_data(weather_station_names, num_rows_to_create):
     coldest_temp = -99.9
     hottest_temp = 99.9
     station_names_10k_max = random.choices(weather_station_names, k=10_000)
-    progress_step = max(1, int(num_rows_to_create / 100))
+    batch_size = 10000 # instead of writing line by line to file, process a batch of stations and put it to disk
+    progress_step = max(1, (num_rows_to_create // batch_size) // 100)
     print('Building test data...')
 
     try:
         with open("../../../data/measurements.txt", 'w') as file:
-            for s in range(0,num_rows_to_create):
-                random_station = random.choice(station_names_10k_max)
-                random_temp = round(random.uniform(coldest_temp, hottest_temp), 1)
-                file.write(f"{random_station};{random_temp}\n")
+            for s in range(0,num_rows_to_create // batch_size):
+                
+                batch = random.choices(station_names_10k_max, k=batch_size)
+                prepped_deviated_batch = '\n'.join([f"{station};{random.uniform(coldest_temp, hottest_temp):.1f}" for station in batch]) # :.1f should quicker than round on a large scale, because round utilizes mathematical operation
+                file.write(prepped_deviated_batch + '\n')
+                
                 # Update progress bar every 1%
                 if s % progress_step == 0 or s == num_rows_to_create - 1:
                     sys.stdout.write('\r')


### PR DESCRIPTION
instead of writing result line by line, implemented random.choices for randomisation of multiple stations and writing large batche ot the disk, also instead of "round" just using :.1f which is probably quicker on a large scale, because it's not a mathematical function

#### Check List:

**not applicable, this just improves generation of test data with Python**

- [ ] You have run `./mvnw verify` and the project builds successfully
- [ ] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [ ] All formatting changes by the build are committed
- [ ] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [ ] Output matches that of `calculate_average_baseline.sh`
- [ ] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time:
* Execution time of reference implementation:

<!--
Thanks for your submission. Please go through the checklist above before submitting your pull request.
Use [x] to mark that the item has been completed.

Due to the large number of entries created so far,
please submit only entries that are you are expecting to run in 10 seconds or less on the evaluation machine.

Please make sure that you have followed the defined rules (https://github.com/gunnarmorling/1brc?tab=readme-ov-file#rules-and-limits).
-->
