### PR TITLE
Final submission

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_merykitty.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_merykitty.java
@@ -227,11 +227,11 @@ public class CalculateAverage_merykitty {
 
         // Find the delimiter ';'
         long semicolons = line.compare(VectorOperators.EQ, ';').toLong();
-        int keySize = Long.numberOfTrailingZeros(semicolons);
 
         // If we cannot find the delimiter in the vector, that means the key is
         // longer than the vector, fall back to scalar processing
-        if (keySize == BYTE_SPECIES.vectorByteSize()) {
+        if (semicolons == 0) {
+            int keySize = BYTE_SPECIES.length();
             while (data.get(ValueLayout.JAVA_BYTE, offset + keySize) != ';') {
                 keySize++;
             }
@@ -240,6 +240,7 @@ public class CalculateAverage_merykitty {
         }
 
         // We inline the searching of the value in the hash map
+        int keySize = Long.numberOfTrailingZeros(semicolons);
         int x;
         int y;
         if (keySize >= Integer.BYTES) {

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_merykittyunsafe.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_merykittyunsafe.java
@@ -356,18 +356,18 @@ public class CalculateAverage_merykittyunsafe {
             long end0 = base + limit0;
             long end1 = base + limit1;
             while (true) {
-                boolean finishes = false;
+                boolean finish = false;
                 if (begin0 < end0) {
                     begin0 = iterate(aggrMap, begin0);
                 }
                 else {
-                    finishes = true;
+                    finish = true;
                 }
                 if (begin1 < end1 - mainLoopMinWidth) {
                     begin1 = iterate(aggrMap, begin1);
                 }
                 else {
-                    if (finishes) {
+                    if (finish) {
                         break;
                     }
                 }

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_merykittyunsafe.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_merykittyunsafe.java
@@ -91,10 +91,12 @@ public class CalculateAverage_merykittyunsafe {
 
         void observe(long entryOffset, long value) {
             long baseOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET + entryOffset;
-            UNSAFE.putShort(this.data, baseOffset + MIN_OFFSET,
-                    (short) Math.min(value, UNSAFE.getShort(this.data, baseOffset + MIN_OFFSET)));
-            UNSAFE.putShort(this.data, baseOffset + MAX_OFFSET,
-                    (short) Math.max(value, UNSAFE.getShort(this.data, baseOffset + MAX_OFFSET)));
+            if (UNSAFE.getShort(this.data, baseOffset + MIN_OFFSET) > value) {
+                UNSAFE.putShort(this.data, baseOffset + MIN_OFFSET, (short) value);
+            }
+            if (UNSAFE.getShort(this.data, baseOffset + MAX_OFFSET) < value) {
+                UNSAFE.putShort(this.data, baseOffset + MAX_OFFSET, (short) value);
+            }
             UNSAFE.putLong(this.data, baseOffset + SUM_OFFSET,
                     value + UNSAFE.getLong(this.data, baseOffset + SUM_OFFSET));
             UNSAFE.putLong(this.data, baseOffset + COUNT_OFFSET,


### PR DESCRIPTION
Some small improvements:

- It is more performant to use branches than to use `min/max`
- Do 2 independent iterations to improve IPC

Some that I have tried:

- Do 4 iterations and use vector instructions to parse all of them at once: LongVector multiplication codegen is horrible, assembling a vector from its elements is expensive, also the constants need to be materialized for each iteration unless the compiler can inline the whole thing.
- Spawning a separate process to hide the cost of unmapping: It is likely that the cost of initializing the VM is higher than the cost of unmap, I did not see improvements.
- Some trickeries to avoid `Unsafe`: Spawning a new segment each time introduces regression, most likely due to failures to inline even with that threshold of inlining, and using a `Long.MAX_VALUE`-size segment introduces additional bound checks.

#### Check List:

- [x] You have run `./mvnw verify` and the project builds successfully
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: Cannot tell, my laptop is not really reliable for benchmarking, but the elapsed time is around 20s.
* Execution time of the previous implementation: Around 26s.
