### PR TITLE
One last improvement for thomaswue

### DIFF
--- a/src/main/java/dev/morling/onebrc/CalculateAverage_thomaswue.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_thomaswue.java
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * split into 3 parts and cursors for each of those parts are processing the segment simultaneously in the same thread.
  * Results are accumulated into {@link Result} objects and a tree map is used to sequentially accumulate the results in
  * the end.
- * Runs in 0.32 on an Intel i9-13900K while the reference implementation takes 120.37s.
+ * Runs in 0.31 on an Intel i9-13900K while the reference implementation takes 120.37s.
  * Credit:
  *  Quan Anh Mai for branchless number parsing code
  *  Alfonso² Peterssen for suggesting memory mapping with unsafe and the subprocess idea

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_thomaswue.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_thomaswue.java
@@ -144,9 +144,15 @@ public class CalculateAverage_thomaswue {
                 long delimiterMask1 = findDelimiter(word1);
                 long delimiterMask2 = findDelimiter(word2);
                 long delimiterMask3 = findDelimiter(word3);
-                Result existingResult1 = findResult(word1, delimiterMask1, scanner1, results, collectedResults);
-                Result existingResult2 = findResult(word2, delimiterMask2, scanner2, results, collectedResults);
-                Result existingResult3 = findResult(word3, delimiterMask3, scanner3, results, collectedResults);
+                long word1b = scanner1.getLongAt(scanner1.pos() + 8);
+                long word2b = scanner2.getLongAt(scanner2.pos() + 8);
+                long word3b = scanner3.getLongAt(scanner3.pos() + 8);
+                long delimiterMask1b = findDelimiter(word1b);
+                long delimiterMask2b = findDelimiter(word2b);
+                long delimiterMask3b = findDelimiter(word3b);
+                Result existingResult1 = findResult(word1, delimiterMask1, word1b, delimiterMask1b, scanner1, results, collectedResults);
+                Result existingResult2 = findResult(word2, delimiterMask2, word2b, delimiterMask2b, scanner2, results, collectedResults);
+                Result existingResult3 = findResult(word3, delimiterMask3, word3b, delimiterMask3b, scanner3, results, collectedResults);
                 long number1 = scanNumber(scanner1);
                 long number2 = scanNumber(scanner2);
                 long number3 = scanNumber(scanner3);
@@ -158,17 +164,23 @@ public class CalculateAverage_thomaswue {
             while (scanner1.hasNext()) {
                 long word = scanner1.getLong();
                 long pos = findDelimiter(word);
-                record(findResult(word, pos, scanner1, results, collectedResults), scanNumber(scanner1));
+                long wordB = scanner1.getLongAt(scanner1.pos() + 8);
+                long posB = findDelimiter(wordB);
+                record(findResult(word, pos, wordB, posB, scanner1, results, collectedResults), scanNumber(scanner1));
             }
             while (scanner2.hasNext()) {
                 long word = scanner2.getLong();
                 long pos = findDelimiter(word);
-                record(findResult(word, pos, scanner2, results, collectedResults), scanNumber(scanner2));
+                long wordB = scanner2.getLongAt(scanner2.pos() + 8);
+                long posB = findDelimiter(wordB);
+                record(findResult(word, pos, wordB, posB, scanner2, results, collectedResults), scanNumber(scanner2));
             }
             while (scanner3.hasNext()) {
                 long word = scanner3.getLong();
                 long pos = findDelimiter(word);
-                record(findResult(word, pos, scanner3, results, collectedResults), scanNumber(scanner3));
+                long wordB = scanner3.getLongAt(scanner3.pos() + 8);
+                long posB = findDelimiter(wordB);
+                record(findResult(word, pos, wordB, posB, scanner3, results, collectedResults), scanNumber(scanner3));
             }
         }
     }
@@ -177,14 +189,15 @@ public class CalculateAverage_thomaswue {
             0xFFFFFFFFFFFFFFFFL };
     private static final long[] MASK2 = new long[]{ 0x00L, 0x00L, 0x00L, 0x00L, 0x00L, 0x00L, 0x00L, 0x00L, 0xFFFFFFFFFFFFFFFFL };
 
-    private static Result findResult(long initialWord, long initialDelimiterMask, Scanner scanner, Result[] results, List<Result> collectedResults) {
+    private static Result findResult(long initialWord, long initialDelimiterMask, long wordB, long delimiterMaskB, Scanner scanner, Result[] results,
+                                     List<Result> collectedResults) {
         Result existingResult;
         long word = initialWord;
         long delimiterMask = initialDelimiterMask;
         long hash;
         long nameAddress = scanner.pos();
-        long word2 = scanner.getLongAt(scanner.pos() + 8);
-        long delimiterMask2 = findDelimiter(word2);
+        long word2 = wordB;
+        long delimiterMask2 = delimiterMaskB;
         if ((delimiterMask | delimiterMask2) != 0) {
             int letterCount1 = Long.numberOfTrailingZeros(delimiterMask) >>> 3; // value between 1 and 8
             int letterCount2 = Long.numberOfTrailingZeros(delimiterMask2) >>> 3; // value between 0 and 8


### PR DESCRIPTION
#### Check List:

- [x] You have run `./mvnw verify` and the project builds successfully
- [x] Tests pass (`./test.sh <username>` shows no differences between expected and actual outputs)
- [x] All formatting changes by the build are committed
- [x] Your launch script is named `calculate_average_<username>.sh` (make sure to match casing of your GH user name) and is executable
- [x] Output matches that of `calculate_average_baseline.sh`
- [x] For new entries, or after substantial changes: When implementing custom hash structures, please point to where you deal with hash collisions (line number)

* Execution time: 0.31
* Execution time of reference implementation: 120.37

OK, so can't let @jerrinot have all the fun alone ;-). I adopted the approach that combines the <8 and 1-16 cases to avoid branch misprediction, which was the biggest improvement; and then also the masking instead of bit shifting, which added another few %. Added @jerrinot and @abeobk to the credits section. This should now get into the ballpark of @jerrinot's submission if the results from my machine don't lie. Major differences to his solution are that I am using Result objects for the hash table instead of unsafe access and I am unrolling 3 times. Also, it avoids the name length check by having the delimiter in the word mask. 