### PR TITLE
Use crac to start faster

### DIFF
--- a/prepare_ianopolousfast.sh
+++ b/prepare_ianopolousfast.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright 2023 The original authors
 #
@@ -15,4 +15,9 @@
 #  limitations under the License.
 #
 
-java -XX:CRaCRestoreFrom=$HOME/ianopolousfast --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ianopolousfast
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+sdk use java 21.0.2.crac-zulu 1>&2
+
+JAVA_OPTS="--enable-preview --add-modules=jdk.incubator.vector -Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=0 -XX:-UseTransparentHugePages -XX:CRaCCheckpointTo=$HOME/ianopolousfast"
+
+java $JAVA_OPTS --class-path target/average-1.0.0-SNAPSHOT.jar dev.morling.onebrc.CalculateAverage_ianopolousfast

--- a/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
+++ b/src/main/java/dev/morling/onebrc/CalculateAverage_ianopolousfast.java
@@ -15,6 +15,7 @@
  */
 package dev.morling.onebrc;
 
+import jdk.crac.Core;
 import jdk.incubator.vector.ByteVector;
 import jdk.incubator.vector.VectorOperators;
 import jdk.incubator.vector.VectorSpecies;
@@ -50,6 +51,7 @@ public class CalculateAverage_ianopolousfast {
             : ByteVector.SPECIES_64;
 
     public static void main(String[] args) throws Exception {
+        Core.checkpointRestore();
         Arena arena = Arena.global();
         Path input = Path.of("measurements.txt");
         FileChannel channel = (FileChannel) Files.newByteChannel(input, StandardOpenOption.READ);


### PR DESCRIPTION
@gunnarmorling I'm trying to get crac working with zulu jvm, but the maven build won't find jdk.crac package. Do I need to change the pom.xml? I can compile and run it fine in IntelliJ.

(GraalVM native-image doesn't support the vector api, hence this route)